### PR TITLE
Removed namespaced tf_static

### DIFF
--- a/clearpath_generator_robot/clearpath_generator_robot/launch/generator.py
+++ b/clearpath_generator_robot/clearpath_generator_robot/launch/generator.py
@@ -166,25 +166,6 @@ class RobotLaunchGenerator(LaunchGenerator):
           namespace=self.namespace,
         )
 
-        # Static transform from <namespace>/odom to odom
-        # See https://github.com/ros-controls/ros2_controllers/pull/533
-        self.tf_namespaced_odom_publisher = LaunchFile.get_static_tf_node(
-            name='namespaced_odom',
-            namespace=self.namespace,
-            parent_link='odom',
-            child_link=f'{self.namespace}/odom',
-            use_sim_time=False,
-        )
-
-        # Static transform from <namespace>/base_link to base_link
-        self.tf_namespaced_base_link_publisher = LaunchFile.get_static_tf_node(
-            name='namespaced_base_link',
-            namespace=self.namespace,
-            parent_link=f'{self.namespace}/base_link',
-            child_link='base_link',
-            use_sim_time=False,
-        )
-
         # Components required for each platform
         common_platform_components = [
             self.wireless_watcher_node,
@@ -265,9 +246,5 @@ class RobotLaunchGenerator(LaunchGenerator):
 
         for component in self.platform_components[self.platform_model]:
             platform_service_launch_writer.add(component)
-
-        if self.namespace not in ('', '/'):
-            platform_service_launch_writer.add(self.tf_namespaced_odom_publisher)
-            platform_service_launch_writer.add(self.tf_namespaced_base_link_publisher)
 
         platform_service_launch_writer.generate_file()


### PR DESCRIPTION
Because of https://github.com/ros-controls/ros2_controllers/commit/6ca402680b88cea90916ef3f350c668ae6abfc35 we no longer need to namespace links. 