### PR TITLE
Republishers

### DIFF
--- a/clearpath_generator_robot/clearpath_generator_robot/launch/sensors.py
+++ b/clearpath_generator_robot/clearpath_generator_robot/launch/sensors.py
@@ -31,6 +31,7 @@
 # of Clearpath Robotics.
 
 from clearpath_config.sensors.types.sensor import BaseSensor
+from clearpath_config.sensors.types.cameras import BaseCamera
 
 from clearpath_generator_common.common import LaunchFile, Package, ParamFile
 from clearpath_generator_common.launch.writer import LaunchWriter
@@ -45,6 +46,10 @@ class SensorLaunch():
         # Launch arguments
         PARAMETERS = 'parameters'
         NAMESPACE = 'namespace'
+        # Republish arguments
+        INPUT = 'input_ns'
+        OUTPUT = 'output_ns'
+        CONTAINER = 'container'
 
         def __init__(self,
                      sensor: BaseSensor,
@@ -75,6 +80,20 @@ class SensorLaunch():
             sensor_writer = LaunchWriter(self.launch_file)
             # Add default sensor launch file
             sensor_writer.add(self.default_sensor_launch_file)
+            # Cameras republishers
+            if self.sensor.get_sensor_type() == BaseCamera.get_sensor_type():
+                for republihser in self.sensor._republishers:
+                    sensor_writer.add(LaunchFile(
+                        "image_%s" % republihser.TYPE,
+                        package=self.CLEARPATH_SENSORS_PACKAGE,
+                        args=[
+                            (self.NAMESPACE, self.namespace),
+                            (self.PARAMETERS, self.parameters.full_path),
+                            (self.INPUT, republihser.input),
+                            (self.OUTPUT, republihser.output),
+                            (self.CONTAINER, 'image_processing_container')
+                        ]
+                    ))
             # Generate sensor launch file
             sensor_writer.generate_file()
 

--- a/clearpath_generator_robot/clearpath_generator_robot/param/sensors.py
+++ b/clearpath_generator_robot/clearpath_generator_robot/param/sensors.py
@@ -31,6 +31,8 @@
 # of Clearpath Robotics.
 
 from clearpath_config.sensors.types.sensor import BaseSensor
+from clearpath_config.sensors.types.cameras import BaseCamera
+from clearpath_config.common.utils.dictionary import merge_dict
 
 from clearpath_generator_common.common import ParamFile, Package
 from clearpath_generator_common.param.writer import ParamWriter
@@ -63,12 +65,25 @@ class SensorParam():
                 parameters={})
             self.default_param_file.read()
 
+            default_parameters = self.default_param_file.parameters
+
+            # Camera republishers
+            if self.sensor.get_sensor_type() == BaseCamera.get_sensor_type():
+                for republisher in self.sensor._republishers:
+                    republisher_file = ParamFile(
+                        name="image_%s" % republisher.TYPE,
+                        package=self.clearpath_sensors_package,
+                        parameters={})
+                    republisher_file.read()
+                    default_parameters = merge_dict(default_parameters,
+                                                    republisher_file.parameters)
+
             # Parameter file to generate
             self.param_file = ParamFile(
                 name=self.sensor.name,
                 namespace=self.namespace,
                 path=self.param_path,
-                parameters=self.default_param_file.parameters)
+                parameters=default_parameters)
 
             self.param_file.update(self.sensor.get_ros_parameters())
 

--- a/clearpath_generator_robot/clearpath_generator_robot/param/sensors.py
+++ b/clearpath_generator_robot/clearpath_generator_robot/param/sensors.py
@@ -70,11 +70,14 @@ class SensorParam():
             # Camera republishers
             if self.sensor.get_sensor_type() == BaseCamera.get_sensor_type():
                 for republisher in self.sensor._republishers:
+                    name = "image_%s" % republisher.TYPE
+                    rename = "image_%s_%s" % (republisher.TYPE, republisher.input)
                     republisher_file = ParamFile(
-                        name="image_%s" % republisher.TYPE,
+                        name=name,
                         package=self.clearpath_sensors_package,
                         parameters={})
                     republisher_file.read()
+                    republisher_file.parameters[rename] = republisher_file.parameters.pop(name)
                     default_parameters = merge_dict(default_parameters,
                                                     republisher_file.parameters)
 

--- a/clearpath_sensors/config/flir_blackfly.yaml
+++ b/clearpath_sensors/config/flir_blackfly.yaml
@@ -16,6 +16,8 @@ flir_blackfly:
     # image_height: 1080
     # offset_x: 16
     # offset_y: 0
+    # binning_x: 1
+    # binning_y: 1
     frame_rate_auto: Off
     frame_rate: 40.0
     frame_rate_enable: true

--- a/clearpath_sensors/config/image_rectify.yaml
+++ b/clearpath_sensors/config/image_rectify.yaml
@@ -1,0 +1,5 @@
+image_rectify:
+  ros__parameters:
+    image_transport: raw
+    interpolation: 1
+    queue_size: 5

--- a/clearpath_sensors/config/image_resize.yaml
+++ b/clearpath_sensors/config/image_resize.yaml
@@ -1,0 +1,9 @@
+image_resize:
+  ros__parameters:
+    image_transport: raw
+    interpolation: 1
+    use_scale: True
+    scale_height: 1.0
+    scale_width: 1.0
+    height: -1
+    width: -1

--- a/clearpath_sensors/launch/image_compressed_to_raw.launch.py
+++ b/clearpath_sensors/launch/image_compressed_to_raw.launch.py
@@ -1,0 +1,71 @@
+# Software License Agreement (BSD)
+#
+# @author    Roni Kreinin <rkreinin@clearpathrobotics.com>
+# @copyright (c) 2023, Clearpath Robotics, Inc., All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# * Redistributions of source code must retain the above copyright notice,
+#   this list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# * Neither the name of Clearpath Robotics nor the names of its contributors
+#   may be used to endorse or promote products derived from this software
+#   without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
+
+
+def generate_launch_description():
+    namespace = LaunchConfiguration('namespace')
+    in_compressed = LaunchConfiguration('in_compressed')
+    out_raw = LaunchConfiguration('out_raw')
+
+    arg_namespace = DeclareLaunchArgument(
+        'namespace',
+        default_value=''
+    )
+
+    arg_in_compressed = DeclareLaunchArgument(
+        'in_compressed',
+        default_value='compressed'
+    )
+
+    arg_out_raw = DeclareLaunchArgument(
+        'out_raw',
+        default_value='image'
+    )
+
+    compressed_transport_node = Node(
+        name="image_compressed_to_raw",
+        namespace=namespace,
+        package="image_transport",
+        executable="republish",
+        remappings=[
+            ('in/compressed', in_compressed),
+            ('out', out_raw),
+        ],
+        arguments=['compressed', 'raw'],
+    )
+
+    ld = LaunchDescription()
+    ld.add_action(arg_namespace)
+    ld.add_action(arg_in_compressed)
+    ld.add_action(arg_out_raw)
+    ld.add_action(compressed_transport_node)
+    return ld

--- a/clearpath_sensors/launch/image_raw_to_compressed.launch.py
+++ b/clearpath_sensors/launch/image_raw_to_compressed.launch.py
@@ -1,0 +1,71 @@
+# Software License Agreement (BSD)
+#
+# @author    Roni Kreinin <rkreinin@clearpathrobotics.com>
+# @copyright (c) 2023, Clearpath Robotics, Inc., All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# * Redistributions of source code must retain the above copyright notice,
+#   this list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# * Neither the name of Clearpath Robotics nor the names of its contributors
+#   may be used to endorse or promote products derived from this software
+#   without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
+
+
+def generate_launch_description():
+    namespace = LaunchConfiguration('namespace')
+    in_raw = LaunchConfiguration('in_raw')
+    out_compressed = LaunchConfiguration('out_compressed')
+
+    arg_namespace = DeclareLaunchArgument(
+        'namespace',
+        default_value=''
+    )
+
+    arg_in_raw = DeclareLaunchArgument(
+        'in_raw',
+        default_value='image'
+    )
+
+    arg_out_compressed = DeclareLaunchArgument(
+        'out_compressed',
+        default_value='compressed'
+    )
+
+    compressed_transport_node = Node(
+        name="image_raw_to_compressed",
+        namespace=namespace,
+        package="image_transport",
+        executable="republish",
+        remappings=[
+            ('in', in_raw),
+            ('out/compressed', out_compressed),
+        ],
+        arguments=['raw', 'compressed'],
+    )
+
+    ld = LaunchDescription()
+    ld.add_action(arg_namespace)
+    ld.add_action(arg_in_raw)
+    ld.add_action(arg_out_compressed)
+    ld.add_action(compressed_transport_node)
+    return ld

--- a/clearpath_sensors/launch/image_raw_to_theora.launch.py
+++ b/clearpath_sensors/launch/image_raw_to_theora.launch.py
@@ -1,0 +1,71 @@
+# Software License Agreement (BSD)
+#
+# @author    Roni Kreinin <rkreinin@clearpathrobotics.com>
+# @copyright (c) 2023, Clearpath Robotics, Inc., All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# * Redistributions of source code must retain the above copyright notice,
+#   this list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# * Neither the name of Clearpath Robotics nor the names of its contributors
+#   may be used to endorse or promote products derived from this software
+#   without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
+
+
+def generate_launch_description():
+    namespace = LaunchConfiguration('namespace')
+    in_raw = LaunchConfiguration('in_raw')
+    out_theora = LaunchConfiguration('out_theora')
+
+    arg_namespace = DeclareLaunchArgument(
+        'namespace',
+        default_value=''
+    )
+
+    arg_in_raw = DeclareLaunchArgument(
+        'in_raw',
+        default_value='image'
+    )
+
+    arg_out_theora = DeclareLaunchArgument(
+        'out_theora',
+        default_value='theora'
+    )
+
+    theora_transport_node = Node(
+        name="image_raw_to_theora",
+        namespace=namespace,
+        package="image_transport",
+        executable="republish",
+        remappings=[
+            ('in', in_raw),
+            ('out/theora', out_theora),
+        ],
+        arguments=['theora', 'raw'],
+    )
+
+    ld = LaunchDescription()
+    ld.add_action(arg_namespace)
+    ld.add_action(arg_in_raw)
+    ld.add_action(arg_out_theora)
+    ld.add_action(theora_transport_node)
+    return ld

--- a/clearpath_sensors/launch/image_raw_to_theora.launch.py
+++ b/clearpath_sensors/launch/image_raw_to_theora.launch.py
@@ -60,7 +60,7 @@ def generate_launch_description():
             ('in', in_raw),
             ('out/theora', out_theora),
         ],
-        arguments=['theora', 'raw'],
+        arguments=['raw', 'theora'],
     )
 
     ld = LaunchDescription()

--- a/clearpath_sensors/launch/image_rectify.launch.py
+++ b/clearpath_sensors/launch/image_rectify.launch.py
@@ -46,7 +46,7 @@ def generate_launch_description():
         default_value=PathJoinSubstitution([
           FindPackageShare('clearpath_sensors'),
           'config',
-          'flir_blackfly.yaml'
+          'image_rectify.yaml'
         ]))
 
     arg_namespace = DeclareLaunchArgument(
@@ -60,9 +60,15 @@ def generate_launch_description():
 
     arg_output_ns = DeclareLaunchArgument(
         'output_ns',
-        default_value='resize'
+        default_value='`rectif`y'
     )
 
+    arg_container = DeclareLaunchArgument(
+        'container',
+        default_value='image_processing_container'
+    )
+
+    # Rectify composable node
     composable_nodes = [
         ComposableNode(
             package='image_proc',
@@ -71,11 +77,14 @@ def generate_launch_description():
             namespace=namespace,
             # Remap subscribers and publishers
             remappings=[
-                ('image', 'mono/image'),
-                ('image_rect', 'mono/image_rect')
+                ('image',  PathJoinSubstitution([input_ns, 'image'])),
+                ('rectify', PathJoinSubstitution([output_ns, 'image'])),
+                ('rectify/compressed', PathJoinSubstitution([output_ns, 'compressed'])),
+                ('rectify/compressedDepth', PathJoinSubstitution([output_ns, 'compressedDepth'])),
+                ('rectify/theora', PathJoinSubstitution([output_ns, 'theora'])),
             ],
-            parameters=[parameters]
-        )
+            parameters=[parameters],
+        ),
     ]
 
     # Create container if none provided, by default look for `image_processing_node`
@@ -101,6 +110,7 @@ def generate_launch_description():
     ld.add_action(arg_namespace)
     ld.add_action(arg_input_ns)
     ld.add_action(arg_output_ns)
+    ld.add_action(arg_container)
     ld.add_action(image_processing_container)
     ld.add_action(load_composable_nodes)
     return ld

--- a/clearpath_sensors/launch/image_rectify.launch.py
+++ b/clearpath_sensors/launch/image_rectify.launch.py
@@ -27,8 +27,9 @@
 # POSSIBILITY OF SUCH DAMAGE.
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
-from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
-from launch_ros.actions import Node, ComposableNodeContainer
+from launch.conditions import LaunchConfigurationEquals, LaunchConfigurationNotEquals
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution, PythonExpression
+from launch_ros.actions import ComposableNodeContainer, LoadComposableNodes
 from launch_ros.descriptions import ComposableNode
 from launch_ros.substitutions import FindPackageShare
 
@@ -36,7 +37,9 @@ from launch_ros.substitutions import FindPackageShare
 def generate_launch_description():
     parameters = LaunchConfiguration('parameters')
     namespace = LaunchConfiguration('namespace')
-    param_mapping_file = LaunchConfiguration('param_mapping_file')
+    input_ns = LaunchConfiguration('input_ns')
+    output_ns = LaunchConfiguration('output_ns')
+    container = LaunchConfiguration('container')
 
     arg_parameters = DeclareLaunchArgument(
         'parameters',
@@ -46,58 +49,38 @@ def generate_launch_description():
           'flir_blackfly.yaml'
         ]))
 
-    arg_param_mapping_file = DeclareLaunchArgument(
-        'param_mapping_file',
-        default_value=PathJoinSubstitution([
-            FindPackageShare('spinnaker_camera_driver'),
-            'config',
-            'blackfly_s.yaml'
-        ]))
-
     arg_namespace = DeclareLaunchArgument(
         'namespace',
         default_value='sensors/camera_0')
 
-    name = "flir_blackfly"
-    blackfly_camera_node = Node(
-        package='spinnaker_camera_driver',
-        namespace=namespace,
-        name=name,
-        executable='camera_driver_node',
-        parameters=[parameters, {'parameter_file': param_mapping_file}],
-        output='screen',
-        remappings=[
-            (name + '/camera_info', 'camera_info'),
-            (name + '/control', 'control'),
-            (name + '/meta', 'meta'),
-            (name + '/image_raw', 'raw/image'),
-            (name + '/image_raw/compressed', 'raw/compressed'),
-            (name + '/image_raw/compressedDepth', 'raw/compressedDepth'),
-            (name + '/image_raw/theora', 'raw/theora'),
-        ]
+    arg_input_ns = DeclareLaunchArgument(
+        'input_ns',
+        default_value='color'
+    )
+
+    arg_output_ns = DeclareLaunchArgument(
+        'output_ns',
+        default_value='resize'
     )
 
     composable_nodes = [
         ComposableNode(
             package='image_proc',
-            plugin='image_proc::DebayerNode',
-            name='image_debayer',
+            plugin='image_proc::RectifyNode',
+            name=PythonExpression(["'image_rectify_", input_ns, "'"]),
             namespace=namespace,
+            # Remap subscribers and publishers
             remappings=[
-                ('image_raw', 'raw/image'),
-                ('image_color', 'color/image'),
-                ('image_color/compressed', 'color/compressed'),
-                ('image_color/compressedDepth', 'color/compressedDepth'),
-                ('image_color/theora', 'color/theora'),
-                ('image_mono', 'mono/image'),
-                ('image_mono/compressed', 'mono/compressed'),
-                ('image_mono/compressedDepth', 'mono/compressedDepth'),
-                ('image_mono/theora', 'mono/theora'),
-            ]
+                ('image', 'mono/image'),
+                ('image_rect', 'mono/image_rect')
+            ],
+            parameters=[parameters]
         )
     ]
 
+    # Create container if none provided, by default look for `image_processing_node`
     image_processing_container = ComposableNodeContainer(
+        condition=LaunchConfigurationEquals('container', ''),
         name='image_processing_container',
         namespace=namespace,
         package='rclcpp_components',
@@ -106,10 +89,18 @@ def generate_launch_description():
         output='screen'
     )
 
+    # Use default container that should have been launched by the camera launch file
+    load_composable_nodes = LoadComposableNodes(
+        condition=LaunchConfigurationNotEquals('container', ''),
+        composable_node_descriptions=composable_nodes,
+        target_container=PythonExpression(["'", namespace, "/", container, "'"])
+    )
+
     ld = LaunchDescription()
     ld.add_action(arg_parameters)
-    ld.add_action(arg_param_mapping_file)
     ld.add_action(arg_namespace)
-    ld.add_action(blackfly_camera_node)
+    ld.add_action(arg_input_ns)
+    ld.add_action(arg_output_ns)
     ld.add_action(image_processing_container)
+    ld.add_action(load_composable_nodes)
     return ld

--- a/clearpath_sensors/launch/image_theora_to_raw.launch.py
+++ b/clearpath_sensors/launch/image_theora_to_raw.launch.py
@@ -1,0 +1,71 @@
+# Software License Agreement (BSD)
+#
+# @author    Roni Kreinin <rkreinin@clearpathrobotics.com>
+# @copyright (c) 2023, Clearpath Robotics, Inc., All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# * Redistributions of source code must retain the above copyright notice,
+#   this list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# * Neither the name of Clearpath Robotics nor the names of its contributors
+#   may be used to endorse or promote products derived from this software
+#   without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
+
+
+def generate_launch_description():
+    namespace = LaunchConfiguration('namespace')
+    in_theora = LaunchConfiguration('in_theora')
+    out_raw = LaunchConfiguration('out_raw')
+
+    arg_namespace = DeclareLaunchArgument(
+        'namespace',
+        default_value=''
+    )
+
+    arg_in_theora = DeclareLaunchArgument(
+        'in_theora',
+        default_value='theora'
+    )
+
+    arg_out_raw = DeclareLaunchArgument(
+        'out_raw',
+        default_value='image'
+    )
+
+    theora_transport_node = Node(
+        name="image_theora_to_raw",
+        namespace=namespace,
+        package="image_transport",
+        executable="republish",
+        remappings=[
+            ('in/theora', in_theora),
+            ('out', out_raw),
+        ],
+        arguments=['theora', 'raw'],
+    )
+
+    ld = LaunchDescription()
+    ld.add_action(arg_namespace)
+    ld.add_action(arg_in_theora)
+    ld.add_action(arg_out_raw)
+    ld.add_action(theora_transport_node)
+    return ld

--- a/clearpath_sensors/package.xml
+++ b/clearpath_sensors/package.xml
@@ -18,6 +18,7 @@
   <exec_depend>flir_camera_description</exec_depend>
   <exec_depend>flir_camera_msgs</exec_depend>
   <exec_depend>image_proc</exec_depend>
+  <exec_depend>image_transport_plugins</exec_depend>
   <exec_depend>microstrain_inertial_driver</exec_depend>
   <exec_depend>nmea_navsat_driver</exec_depend>
   <exec_depend>realsense2_camera</exec_depend>


### PR DESCRIPTION
Launch files to convert to and from raw images and compressed/theora images. 
- `image_raw_to_compressed.launch.py`
- `image_compressed_to_raw.launch.py`
- `image_raw_to_theora.launch.py`
- `image_theora_to_raw.launch.py`

Launch and param files to rectify and resize images:
- `image_rectify.launch.py`
- `image_resize.launch.py`

Added re-publishers to generator.

Added `image_transport_plugins` as dependency.
