### PR TITLE
Valence bms support

### DIFF
--- a/clearpath_generator_robot/package.xml
+++ b/clearpath_generator_robot/package.xml
@@ -17,6 +17,7 @@
   <exec_depend>imu_filter_madgwick</exec_depend>
   <exec_depend>micro_ros_agent</exec_depend>
   <exec_depend>sevcon_traction</exec_depend>
+  <exec_depend>valence_bms_driver</exec_depend>
   <exec_depend>wireless_watcher</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>


### PR DESCRIPTION
Launches the Valence BMS Driver using information passed through from the robot.yaml. 

Tested on a test PC, still needs more thorough testing on a full unit with valence battery to ensure a smooth experience.