### PR TITLE
Added discovery server service

### DIFF
--- a/clearpath_robot/scripts/generate
+++ b/clearpath_robot/scripts/generate
@@ -1,8 +1,12 @@
 #!/bin/bash
 source /opt/ros/humble/setup.bash
+
 # Generate and source setup.bash
 ros2 run clearpath_generator_common generate_bash
-source /etc/clearpath/setup.bash
+source /etc/clearpath/setup.bash no-super-client
+
+# Generate discovery server start file
+ros2 run clearpath_generator_common generate_discovery_server
 
 # Generate description
 ros2 run clearpath_generator_common generate_description

--- a/clearpath_robot/scripts/generate
+++ b/clearpath_robot/scripts/generate
@@ -3,7 +3,7 @@ source /opt/ros/humble/setup.bash
 
 # Generate and source setup.bash
 ros2 run clearpath_generator_common generate_bash
-source /etc/clearpath/setup.bash no-super-client
+source /etc/clearpath/setup.bash
 
 # Generate discovery server start file
 ros2 run clearpath_generator_common generate_discovery_server

--- a/clearpath_robot/scripts/install
+++ b/clearpath_robot/scripts/install
@@ -84,6 +84,33 @@ class SensorsProvider(robot_upstart.providers.Generic):
             }}
 
 
+class DiscoveryServerProvider(robot_upstart.providers.Generic):
+    def post_install(self):
+        pass
+
+    def generate_install(self):
+        discovery_service_path = os.path.join(
+            get_package_share_directory('clearpath_robot'),
+            'services/clearpath-discovery.service')
+        with open(discovery_service_path) as f:
+            discovery_service_contents : str = ''
+            discovery_service_lines = f.readlines()
+            for line in discovery_service_lines:
+                # Replace User with username from config
+                if 'User=' in line:
+                    line = 'User={0}\n'.format(clearpath_config.system.username)
+                discovery_service_contents += line
+
+        return {
+            "/lib/systemd/system/clearpath-discovery.service": {
+                "content": discovery_service_contents,
+                "mode": 0o644
+            },
+            "/etc/systemd/system/clearpath-robot.service.wants/clearpath-discovery.service": {
+                "symlink": "/lib/systemd/system/clearpath-discovery.service"
+            }}
+
+
 class RobotProvider(robot_upstart.providers.Generic):
     def post_install(self):
         pass
@@ -123,8 +150,7 @@ class RobotProvider(robot_upstart.providers.Generic):
             "/usr/sbin/clearpath-robot-check": {
                 "content": robot_service_exec_contents,
                 "mode": 0o755
-            },
-          }
+            }}
 
 
 setup_path = BaseGenerator.get_args()
@@ -146,7 +172,7 @@ config = read_yaml(config_path)
 # Parse YAML into config
 clearpath_config = ClearpathConfig(config)
 
-rmw = clearpath_config.system.rmw_implementation
+rmw = clearpath_config.system.middleware.rmw_implementation
 domain_id = clearpath_config.system.domain_id
 
 # Platform
@@ -174,6 +200,10 @@ sensors.install()
 
 sensors_extras = robot_upstart.Job(workspace_setup=workspace_setup)
 sensors_extras.install(Provider=SensorsProvider)
+
+# Discovery Server
+discovery_server = robot_upstart.Job(workspace_setup=workspace_setup)
+discovery_server.install(Provider=DiscoveryServerProvider)
 
 # Robot
 robot = robot_upstart.Job(workspace_setup=workspace_setup)

--- a/clearpath_robot/scripts/install
+++ b/clearpath_robot/scripts/install
@@ -58,7 +58,11 @@ class PlatformProvider(robot_upstart.providers.Generic):
             "/lib/systemd/system/clearpath-platform.service": {
                 "content": platform_service_contents,
                 "mode": 0o644
-            }}
+            },
+            "/etc/systemd/system/clearpath-robot.service.wants/clearpath-platform.service": {
+                "symlink": "/lib/systemd/system/clearpath-platform.service"
+            }
+        }
 
 
 class SensorsProvider(robot_upstart.providers.Generic):
@@ -81,7 +85,11 @@ class SensorsProvider(robot_upstart.providers.Generic):
             "/lib/systemd/system/clearpath-sensors.service": {
                 "content": sensors_service_contents,
                 "mode": 0o644
-            }}
+            },
+            "/etc/systemd/system/clearpath-robot.service.wants/clearpath-sensors.service": {
+                "symlink": "/lib/systemd/system/clearpath-sensors.service"
+            }
+        }
 
 
 class DiscoveryServerProvider(robot_upstart.providers.Generic):
@@ -93,7 +101,7 @@ class DiscoveryServerProvider(robot_upstart.providers.Generic):
             get_package_share_directory('clearpath_robot'),
             'services/clearpath-discovery.service')
         with open(discovery_service_path) as f:
-            discovery_service_contents : str = ''
+            discovery_service_contents: str = ''
             discovery_service_lines = f.readlines()
             for line in discovery_service_lines:
                 # Replace User with username from config
@@ -108,7 +116,8 @@ class DiscoveryServerProvider(robot_upstart.providers.Generic):
             },
             "/etc/systemd/system/clearpath-robot.service.wants/clearpath-discovery.service": {
                 "symlink": "/lib/systemd/system/clearpath-discovery.service"
-            }}
+            }
+        }
 
 
 class RobotProvider(robot_upstart.providers.Generic):
@@ -150,7 +159,8 @@ class RobotProvider(robot_upstart.providers.Generic):
             "/usr/sbin/clearpath-robot-check": {
                 "content": robot_service_exec_contents,
                 "mode": 0o755
-            }}
+            }
+        }
 
 
 setup_path = BaseGenerator.get_args()

--- a/clearpath_robot/services/clearpath-discovery.service
+++ b/clearpath_robot/services/clearpath-discovery.service
@@ -1,0 +1,14 @@
+[Unit]
+Description="Clearpath FastDDS discovery server"
+PartOf=clearpath-robot.service
+After=clearpath-robot.service
+
+[Service]
+User=administrator
+Type=simple
+Restart=on-failure
+RestartSec=1
+ExecStart=/bin/bash -e /etc/clearpath/discovery-server-start
+
+[Install]
+WantedBy=clearpath-robot.service

--- a/clearpath_robot/services/clearpath-platform.service
+++ b/clearpath_robot/services/clearpath-platform.service
@@ -1,5 +1,5 @@
 [Unit]
-Description="bringup clearpath-platform"
+Description="Clearpath robot sub-service, launch all platform nodes"
 PartOf=clearpath-robot.service
 After=clearpath-robot.service
 

--- a/clearpath_robot/services/clearpath-robot.service
+++ b/clearpath_robot/services/clearpath-robot.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Application
+Description="Clearpath robot main generation and bringup service"
 
 [Service]
 User=administrator

--- a/clearpath_robot/services/clearpath-sensors.service
+++ b/clearpath_robot/services/clearpath-sensors.service
@@ -1,5 +1,5 @@
 [Unit]
-Description="bringup clearpath-sensors"
+Description="Clearpath robot sub-service, launch all sensor nodes"
 PartOf=clearpath-robot.service
 After=clearpath-robot.service
 


### PR DESCRIPTION
Service will always run but if discovery server is not configured in the robot.yaml then it will end gracefully with a message in the log. The service relaunches every time the robot.yaml is modified along with the other services.