### PR TITLE
Fix tf_static for realsense and microstrain

### DIFF
--- a/clearpath_generator_robot/clearpath_generator_robot/launch/sensors.py
+++ b/clearpath_generator_robot/clearpath_generator_robot/launch/sensors.py
@@ -45,6 +45,7 @@ class SensorLaunch():
     # Launch arguments
     PARAMETERS = 'parameters'
     NAMESPACE = 'namespace'
+    ROBOT_NAMESPACE = 'robot_namespace'
     # Republish arguments
     INPUT = 'input_ns'
     OUTPUT = 'output_ns'
@@ -69,7 +70,8 @@ class SensorLaunch():
         # Set launch args for default launch file
         self.launch_args = [
             (self.PARAMETERS, self.parameters.full_path),
-            (self.NAMESPACE, self.namespace)
+            (self.NAMESPACE, self.namespace),
+            (self.ROBOT_NAMESPACE, self._robot_namespace),
         ]
 
         self.default_sensor_launch_file = LaunchFile(

--- a/clearpath_sensors/launch/intel_realsense.launch.py
+++ b/clearpath_sensors/launch/intel_realsense.launch.py
@@ -29,7 +29,7 @@ from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
 from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
 
-from launch_ros.actions import Node, ComposableNodeContainer
+from launch_ros.actions import ComposableNodeContainer, Node
 from launch_ros.substitutions import FindPackageShare
 
 
@@ -54,7 +54,7 @@ def generate_launch_description():
         'robot_namespace',
         default_value='')
 
-    name = "intel_realsense"
+    name = 'intel_realsense'
     realsense2_camera_node = Node(
         package='realsense2_camera',
         namespace=namespace,
@@ -85,7 +85,7 @@ def generate_launch_description():
             ('infra2/image_rect_raw/theora', 'infra2/theora'),
             # Points
             ('depth/color/points', 'points'),
-            #TF
+            # TF
             ('/tf_static', PathJoinSubstitution(['/', robot_namespace, 'tf_static']))
         ]
     )

--- a/clearpath_sensors/launch/intel_realsense.launch.py
+++ b/clearpath_sensors/launch/intel_realsense.launch.py
@@ -36,6 +36,7 @@ from launch_ros.substitutions import FindPackageShare
 def generate_launch_description():
     parameters = LaunchConfiguration('parameters')
     namespace = LaunchConfiguration('namespace')
+    robot_namespace = LaunchConfiguration('robot_namespace')
 
     arg_parameters = DeclareLaunchArgument(
         'parameters',
@@ -47,6 +48,10 @@ def generate_launch_description():
 
     arg_namespace = DeclareLaunchArgument(
         'namespace',
+        default_value='')
+
+    arg_robot_namespace = DeclareLaunchArgument(
+        'robot_namespace',
         default_value='')
 
     name = "intel_realsense"
@@ -80,6 +85,8 @@ def generate_launch_description():
             ('infra2/image_rect_raw/theora', 'infra2/theora'),
             # Points
             ('depth/color/points', 'points'),
+            #TF
+            ('/tf_static', PathJoinSubstitution(['/', robot_namespace, 'tf_static']))
         ]
     )
 
@@ -95,6 +102,7 @@ def generate_launch_description():
     ld = LaunchDescription()
     ld.add_action(arg_parameters)
     ld.add_action(arg_namespace)
+    ld.add_action(arg_robot_namespace)
     ld.add_action(realsense2_camera_node)
     ld.add_action(image_processing_container)
     return ld

--- a/clearpath_sensors/launch/microstrain_imu.launch.py
+++ b/clearpath_sensors/launch/microstrain_imu.launch.py
@@ -51,7 +51,7 @@ def generate_launch_description():
     arg_robot_namespace = DeclareLaunchArgument(
         'robot_namespace',
         default_value='')
-    
+
     arg_parameters = DeclareLaunchArgument(
         'parameters',
         default_value=PathJoinSubstitution([

--- a/clearpath_sensors/launch/microstrain_imu.launch.py
+++ b/clearpath_sensors/launch/microstrain_imu.launch.py
@@ -39,6 +39,7 @@ def generate_launch_description():
 
     parameters = LaunchConfiguration('parameters')
     namespace = LaunchConfiguration('namespace')
+    robot_namespace = LaunchConfiguration('robot_namespace')
 
     launch_microstrain_imu = PathJoinSubstitution([
         pkg_microstrain_inertial_driver, 'launch', 'microstrain_launch.py'])
@@ -47,6 +48,10 @@ def generate_launch_description():
         'namespace',
         default_value='')
 
+    arg_robot_namespace = DeclareLaunchArgument(
+        'robot_namespace',
+        default_value='')
+    
     arg_parameters = DeclareLaunchArgument(
         'parameters',
         default_value=PathJoinSubstitution([
@@ -59,6 +64,7 @@ def generate_launch_description():
         SetRemap('imu/data', 'data'),
         SetRemap('/moving_ang', 'moving_ang'),
         SetRemap('/tf', 'tf'),
+        SetRemap('/tf_static', PathJoinSubstitution(['/', robot_namespace, 'tf_static'])),
 
         IncludeLaunchDescription(
           PythonLaunchDescriptionSource([launch_microstrain_imu]),
@@ -73,6 +79,7 @@ def generate_launch_description():
 
     ld = LaunchDescription()
     ld.add_action(arg_namespace)
+    ld.add_action(arg_robot_namespace)
     ld.add_action(arg_parameters)
     ld.add_action(launch_microstrain_imu)
     return ld


### PR DESCRIPTION
Pass the robot namespace to all of the sensor launch files and specifically for realsense and microstrain remap the /tf_static topic to /robot_namespace/tf_static. 

We will need to review the other sensors to see which other ones need this as well. 