### PR TITLE
OAKD Pointcloud

### DIFF
--- a/clearpath_generator_robot/clearpath_generator_robot/param/sensors.py
+++ b/clearpath_generator_robot/clearpath_generator_robot/param/sensors.py
@@ -92,6 +92,11 @@ class SensorParam():
 
         self.param_file.update(self.sensor.get_ros_parameters())
 
+        if 'luxonis_oakd' in self.param_file.parameters:
+            luxonis_params = self.param_file.parameters['luxonis_oakd']
+            self.param_file.parameters[self.sensor.name] = luxonis_params
+            self.param_file.parameters.pop('luxonis_oakd')
+
     def generate_config(self):
         sensor_writer = ParamWriter(self.param_file)
         sensor_writer.write_file()

--- a/clearpath_sensors/config/luxonis_oakd.yaml
+++ b/clearpath_sensors/config/luxonis_oakd.yaml
@@ -1,4 +1,4 @@
-oakd:
+luxonis_oakd:
   ros__parameters:
     camera:
       i_enable_imu: false
@@ -6,20 +6,17 @@ oakd:
       i_floodlight_brightness: 0
       i_laser_dot_brightness: 100
       i_nn_type: none
-      i_pipeline_type: RGB
+      i_pipeline_type: RGBD
       i_usb_speed: SUPER_PLUS
       i_usb_port_id: ''
     rgb:
       i_board_socket_id: 0
       i_fps: 30.0
       i_height: 720
-      i_interleaved: false
+      i_width: 1280
       i_max_q_size: 10
-      i_preview_size: 250
-      i_enable_preview: true
-      i_low_bandwidth: true
-      i_keep_preview_aspect_ratio: true
-      i_publish_topic: false
-      i_resolution: '1080P'
+    stereo:
+      i_fps: 30.0
+      i_height: 720
       i_width: 1280
     use_sim_time: false

--- a/clearpath_sensors/launch/luxonis_oakd.launch.py
+++ b/clearpath_sensors/launch/luxonis_oakd.launch.py
@@ -75,13 +75,12 @@ def launch_setup(context):
 
     depthai_pcl_node = ComposableNode(
         package='depth_image_proc',
-        plugin='depth_image_proc::PointCloudXyzrgbNode',
-        name='point_cloud_xyzrgb_node',
+        plugin='depth_image_proc::PointCloudXyzNode',
+        name='point_cloud_xyz_node',
         namespace=namespace,
         remappings=[
-            ('depth_registered/image_rect', 'stereo/image'),
-            ('rgb/image_rect_color', 'color/image'),
-            ('rgb/camera_info', 'color/camera_info'),
+            ('image_rect', 'stereo/image'),
+            ('camera_info', 'stereo/camera_info'),
         ],
     )
 


### PR DESCRIPTION
The DepthAI driver uses the node name as the link prefix. Therefore, the generators has a specific check for the luxonis_oakd parameter and launch file to make sure that the name of the node is updated to match the name of the sensor.