### PR TITLE
Velodyne tf and tf_static should be remapped to the robot namespace

### DIFF
--- a/clearpath_sensors/launch/velodyne_lidar.launch.py
+++ b/clearpath_sensors/launch/velodyne_lidar.launch.py
@@ -56,7 +56,7 @@ def generate_launch_description():
         namespace=namespace,
         parameters=[parameters],
         remappings=[
-          ('/diagnostics', 'diagnostics')
+          ('/diagnostics', 'diagnostics'), ('/tf', 'tf'), ('/tf_static', 'tf_static')
         ],
         output='screen'
     )
@@ -68,7 +68,7 @@ def generate_launch_description():
         output='screen',
         parameters=[parameters],
         remappings=[
-          ('/diagnostics', 'diagnostics')
+          ('/diagnostics', 'diagnostics'), ('/tf', 'tf'), ('/tf_static', 'tf_static')
         ],
     )
 

--- a/clearpath_sensors/launch/velodyne_lidar.launch.py
+++ b/clearpath_sensors/launch/velodyne_lidar.launch.py
@@ -56,7 +56,7 @@ def generate_launch_description():
         namespace=namespace,
         parameters=[parameters],
         remappings=[
-          ('/diagnostics', 'diagnostics'), ('/tf', 'tf'), ('/tf_static', 'tf_static')
+          ('/diagnostics', 'diagnostics'),
         ],
         output='screen'
     )
@@ -68,7 +68,9 @@ def generate_launch_description():
         output='screen',
         parameters=[parameters],
         remappings=[
-          ('/diagnostics', 'diagnostics'), ('/tf', 'tf'), ('/tf_static', 'tf_static')
+          ('/diagnostics', 'diagnostics'),
+          ('/tf', 'tf'),
+          ('/tf_static', 'tf_static'),
         ],
     )
 


### PR DESCRIPTION
I think that, as it happens for all the other sensors, the topics /tf and /tf_static should be remapped to the namespace of the robot. 