### PR TITLE
Add dependency on `inventus_bmu`

### DIFF
--- a/clearpath_generator_robot/package.xml
+++ b/clearpath_generator_robot/package.xml
@@ -16,6 +16,7 @@
   <exec_depend>clearpath_motor_msgs</exec_depend>
   <exec_depend>clearpath_sensors</exec_depend>
   <exec_depend>imu_filter_madgwick</exec_depend>
+  <exec_depend>inventus_bmu</exec_depend>
   <exec_depend>micro_ros_agent</exec_depend>
   <!--<exec_depend>sevcon_traction</exec_depend>-->
   <exec_depend>valence_bms_driver</exec_depend>


### PR DESCRIPTION
This package appears necessary for A300 support, and should be included in the dependencies.