### PR TITLE
Move package initializations out of clearpath_generator_common

### DIFF
--- a/clearpath_generator_robot/clearpath_generator_robot/launch/generator.py
+++ b/clearpath_generator_robot/clearpath_generator_robot/launch/generator.py
@@ -46,6 +46,10 @@ class RobotLaunchGenerator(LaunchGenerator):
     def __init__(self, setup_path: str = '/etc/clearpath/') -> None:
         super().__init__(setup_path)
 
+        # Additional packages specific to physical robots
+        self.pkg_clearpath_sensors = Package('clearpath_sensors')
+        self.pkg_clearpath_hardware_interfaces = Package('clearpath_hardware_interfaces')
+
         # Filter for MCU IMU
         self.imu_0_filter_node = LaunchFile.Node(
             package='imu_filter_madgwick',

--- a/clearpath_generator_robot/clearpath_generator_robot/param/generator.py
+++ b/clearpath_generator_robot/clearpath_generator_robot/param/generator.py
@@ -32,11 +32,19 @@
 # modification, is not permitted without the express permission
 # of Clearpath Robotics.
 
+from clearpath_generator_common.common import Package
 from clearpath_generator_common.param.generator import ParamGenerator
 from clearpath_generator_robot.param.sensors import SensorParam
 
 
 class RobotParamGenerator(ParamGenerator):
+
+    def __init__(self, setup_path: str = '/etc/clearpath') -> None:
+        super().__init__(setup_path=setup_path)
+
+        # Additional packages specific to physical robots
+        self.pkg_clearpath_sensors = Package('clearpath_sensors')
+        self.pkg_clearpath_hardware_interfaces = Package('clearpath_hardware_interfaces')
 
     def generate_sensors(self) -> None:
         sensors = self.clearpath_config.sensors.get_all_sensors()

--- a/clearpath_generator_robot/package.xml
+++ b/clearpath_generator_robot/package.xml
@@ -13,6 +13,7 @@
   <exec_depend>clearpath_config</exec_depend>
   <exec_depend>clearpath_diagnostics</exec_depend>
   <exec_depend>clearpath_generator_common</exec_depend>
+  <exec_depend>clearpath_hardware_interfaces</exec_depend>
   <exec_depend>clearpath_motor_msgs</exec_depend>
   <exec_depend>clearpath_sensors</exec_depend>
   <exec_depend>imu_filter_madgwick</exec_depend>


### PR DESCRIPTION
Relates to: https://github.com/clearpathrobotics/clearpath_common/pull/129

Package initializations that used to be in clearpath_generator_common are moved into the local generators, as they relate to robot-specific packages.

Once merged this should be cherry-picked into Humble