### PR TITLE
CAN bootloader fixes

### DIFF
--- a/clearpath_motor_drivers/lynx_motor_driver/include/lynx_motor_driver/lynx_motor_driver.hpp
+++ b/clearpath_motor_drivers/lynx_motor_driver/include/lynx_motor_driver/lynx_motor_driver.hpp
@@ -182,7 +182,7 @@ private:
   // Update application
   std::queue<uint8_t> update_app_queue_;
   uint32_t update_app_size_;
-  uint32_t can_count_;
+  uint32_t app_count_, can_count_;
 
   // Get COBID from message ID
   uint32_t getCOBID(const uint32_t id) const;

--- a/clearpath_motor_drivers/lynx_motor_driver/include/lynx_motor_driver/lynx_motor_driver.hpp
+++ b/clearpath_motor_drivers/lynx_motor_driver/include/lynx_motor_driver/lynx_motor_driver.hpp
@@ -139,12 +139,13 @@ public:
   // Action getters
   bool tryGetIteration(uint16_t & iteration);
   bool tryGetOffset(float & offset);
-  bool tryGetUpdateAck();
+  bool tryGetUpdateAck(uint16_t & can_count);
   bool tryGetUpdateAlive();
-  void getUpdateAck();
+  void getUpdateAck(uint16_t & can_count);
   void getUpdateAlive();
 
   // Update functions
+  void updateReset();
   void copyApplication(const std::queue<uint8_t> app);
   float updateApp();
 
@@ -181,6 +182,7 @@ private:
   // Update application
   std::queue<uint8_t> update_app_queue_;
   uint32_t update_app_size_;
+  uint32_t can_count_;
 
   // Get COBID from message ID
   uint32_t getCOBID(const uint32_t id) const;

--- a/clearpath_motor_drivers/lynx_motor_driver/src/lynx_motor_driver.cpp
+++ b/clearpath_motor_drivers/lynx_motor_driver/src/lynx_motor_driver.cpp
@@ -616,6 +616,7 @@ void LynxMotorDriver::updateReset()
   (void)tryGetUpdateAck(temp);
   (void)tryGetUpdateAlive();
   can_count_ = 0;
+  app_count_ = 0;
 }
 
 /**
@@ -636,7 +637,6 @@ void LynxMotorDriver::copyApplication(const std::queue<uint8_t> app)
  */
 float LynxMotorDriver::updateApp()
 {
-  static uint16_t app_count;
   uint16_t can_count;
   uint8_t frame_data[8];
 
@@ -649,14 +649,14 @@ float LynxMotorDriver::updateApp()
       update_app_queue_.pop();
     }
 
-    app_count++;
+    app_count_++;
 
     do
     {
       send(CAN_MSGID_BOOT_DATA, frame_data, 8);
       // Wait for ACK
       getUpdateAck(can_count);
-    } while (can_count != app_count);
+    } while (can_count < app_count_);
   }
   else // Send remaining bytes
   {
@@ -674,14 +674,14 @@ float LynxMotorDriver::updateApp()
       }
     }
   
-    app_count++;
+    app_count_++;
 
     do
     {
       send(CAN_MSGID_BOOT_DATA, frame_data, 8);
       // Wait for ACK
       getUpdateAck(can_count);
-    } while (can_count != app_count);
+    } while (can_count < app_count_);
   }
 
   // Calculate progress

--- a/clearpath_motor_drivers/lynx_motor_driver/src/lynx_motor_driver.cpp
+++ b/clearpath_motor_drivers/lynx_motor_driver/src/lynx_motor_driver.cpp
@@ -649,12 +649,12 @@ float LynxMotorDriver::updateApp()
       update_app_queue_.pop();
     }
 
-    send(CAN_MSGID_BOOT_DATA, frame_data, 8);
     app_count++;
 
-    // Wait for ACK
     do
     {
+      send(CAN_MSGID_BOOT_DATA, frame_data, 8);
+      // Wait for ACK
       getUpdateAck(can_count);
     } while (can_count != app_count);
   }
@@ -674,12 +674,12 @@ float LynxMotorDriver::updateApp()
       }
     }
   
-    send(CAN_MSGID_BOOT_DATA, frame_data, 8);
     app_count++;
 
-    // Wait for ACK
     do
     {
+      send(CAN_MSGID_BOOT_DATA, frame_data, 8);
+      // Wait for ACK
       getUpdateAck(can_count);
     } while (can_count != app_count);
   }

--- a/clearpath_motor_drivers/lynx_motor_driver/src/lynx_motor_driver.cpp
+++ b/clearpath_motor_drivers/lynx_motor_driver/src/lynx_motor_driver.cpp
@@ -318,13 +318,14 @@ bool LynxMotorDriver::processMessage(const Message& received_msg)
 
     case CAN_MSGID_BOOT_RESP:
     {
-      uint8_t resp = received_msg.getDataAsUint8();
+      uint16_t resp = received_msg.getDataAsUint16();
       if (resp == 0)
       {
         action_mutexes_[Action::Fields::UpdateAlive]->unlock();
       }
-      else if (resp == 1)
+      else
       {
+        can_count_ = resp;
         action_mutexes_[Action::Fields::UpdateAck]->unlock();
       }
       break;
@@ -609,6 +610,14 @@ void LynxMotorDriver::sendBootAliveCheck()
   send(CAN_MSGID_BOOT_ALIVE);
 }
 
+void LynxMotorDriver::updateReset()
+{
+  uint16_t temp;
+  (void)tryGetUpdateAck(temp);
+  (void)tryGetUpdateAlive();
+  can_count_ = 0;
+}
+
 /**
  * @brief Copy the application to the driver.
  * 
@@ -627,6 +636,8 @@ void LynxMotorDriver::copyApplication(const std::queue<uint8_t> app)
  */
 float LynxMotorDriver::updateApp()
 {
+  static uint16_t app_count;
+  uint16_t can_count;
   uint8_t frame_data[8];
 
   if (update_app_queue_.size() >= 8)
@@ -639,9 +650,13 @@ float LynxMotorDriver::updateApp()
     }
 
     send(CAN_MSGID_BOOT_DATA, frame_data, 8);
+    app_count++;
 
     // Wait for ACK
-    getUpdateAck();
+    do
+    {
+      getUpdateAck(can_count);
+    } while (can_count != app_count);
   }
   else // Send remaining bytes
   {
@@ -660,9 +675,13 @@ float LynxMotorDriver::updateApp()
     }
   
     send(CAN_MSGID_BOOT_DATA, frame_data, 8);
+    app_count++;
 
     // Wait for ACK
-    getUpdateAck();
+    do
+    {
+      getUpdateAck(can_count);
+    } while (can_count != app_count);
   }
 
   // Calculate progress
@@ -715,9 +734,15 @@ bool LynxMotorDriver::tryGetOffset(float & offset)
  * @return true if acquired.
  * @return false otherwise.
  */
-bool LynxMotorDriver::tryGetUpdateAck()
+bool LynxMotorDriver::tryGetUpdateAck(uint16_t & can_count)
 {
-  return action_mutexes_[Action::Fields::UpdateAck]->try_lock();
+  if (action_mutexes_[Action::Fields::UpdateAck]->try_lock())
+  {
+    can_count = can_count_;
+    return true;
+  }
+
+  return false;
 }
 
 /**
@@ -735,9 +760,10 @@ bool LynxMotorDriver::tryGetUpdateAlive()
  * @brief Acquire the update ack mutex.
  * Blocks until acquired.
  */
-void LynxMotorDriver::getUpdateAck()
+void LynxMotorDriver::getUpdateAck(uint16_t & can_count)
 {
-  return action_mutexes_[Action::Fields::UpdateAck]->lock();
+  action_mutexes_[Action::Fields::UpdateAck]->lock();
+  can_count = can_count_;
 }
 
 /**
@@ -746,7 +772,7 @@ void LynxMotorDriver::getUpdateAck()
  */
 void LynxMotorDriver::getUpdateAlive()
 {
-  return action_mutexes_[Action::Fields::UpdateAlive]->lock();
+  action_mutexes_[Action::Fields::UpdateAlive]->lock();
 }
 
 }  // namespace lynx_motor_driver

--- a/clearpath_motor_drivers/lynx_motor_driver/src/update_action.cpp
+++ b/clearpath_motor_drivers/lynx_motor_driver/src/update_action.cpp
@@ -32,6 +32,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
 // Binary files will have 15 reserved bytes that should be ignored
 static constexpr uint8_t BINARY_FILE_RESERVED_BYTE_START_INDEX = 3;
 static constexpr uint8_t BINARY_FILE_RESERVED_BYTE_END_INDEX = 18;
+static constexpr uint8_t ALIVE_CHECK_ATTEMPTS = 5;
 
 /**
  * @brief Read
@@ -172,28 +173,17 @@ void LynxMotorNode::executeUpdateAction(const std::shared_ptr<GoalHandleUpdate> 
   float progress = 0.0f;
   float last_progress = 0.0f;
   uint8_t i = 0;
+  uint16_t counter = 0;
 
   RCLCPP_INFO(this->get_logger(), "Executing goal");
-
-  for (auto & driver : drivers_)
-  {
-    // Reset update variables
-    driver.updateReset();
-    // Send Boot request to each driver
-    RCLCPP_INFO(this->get_logger(), "Send boot request to %s", driver.getJointName().c_str());
-    driver.sendBootRequest();
-  }
-
-  // Allow time for Lynx to enter bootloader
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
   // Update each driver sequentially
   for (auto & driver : drivers_)
   {
     last_progress = 0.0f;
 
-    RCLCPP_INFO(this->get_logger(), "Send alive check to %s", driver.getJointName().c_str());
-    driver.sendBootAliveCheck();
+    // Reset update variables
+    driver.updateReset();
 
     // Wait for Lynx Alive response
     do {
@@ -204,8 +194,27 @@ void LynxMotorNode::executeUpdateAction(const std::shared_ptr<GoalHandleUpdate> 
         return;
       }
 
-      std::this_thread::sleep_for(std::chrono::milliseconds(1));
-    } while (!driver.tryGetUpdateAlive());
+      // Send Boot request
+      RCLCPP_INFO(this->get_logger(), "Send boot request to %s", driver.getJointName().c_str());
+      driver.sendBootRequest();
+
+      // Allow time for Lynx to enter bootloader
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+      // Send alive check
+      RCLCPP_INFO(this->get_logger(), "Send alive check to %s", driver.getJointName().c_str());
+      driver.sendBootAliveCheck();
+
+      std::this_thread::sleep_for(std::chrono::milliseconds(400));
+      counter++;
+    } while (!driver.tryGetUpdateAlive() && counter < ALIVE_CHECK_ATTEMPTS);
+
+    // Lynx did not respond in time
+    if (counter == ALIVE_CHECK_ATTEMPTS)
+    {
+      RCLCPP_INFO(this->get_logger(), "Driver %s is unresponsive, skipping", driver.getJointName().c_str());
+      continue;
+    }
 
     RCLCPP_INFO(this->get_logger(), "Driver %s is in bootloader", driver.getJointName().c_str());
 
@@ -241,7 +250,6 @@ void LynxMotorNode::executeUpdateAction(const std::shared_ptr<GoalHandleUpdate> 
   // Check if goal is done
   if (rclcpp::ok()) {
     goal_handle->succeed(result);
-    RCLCPP_INFO(this->get_logger(), "Update succeeded");
     updating_ = false;
   }
 }

--- a/clearpath_motor_drivers/lynx_motor_driver/src/update_action.cpp
+++ b/clearpath_motor_drivers/lynx_motor_driver/src/update_action.cpp
@@ -32,7 +32,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
 // Binary files will have 15 reserved bytes that should be ignored
 static constexpr uint8_t BINARY_FILE_RESERVED_BYTE_START_INDEX = 3;
 static constexpr uint8_t BINARY_FILE_RESERVED_BYTE_END_INDEX = 18;
-static constexpr uint8_t ALIVE_CHECK_ATTEMPTS = 5;
+static constexpr uint8_t ALIVE_CHECK_ATTEMPTS = 100;
 
 /**
  * @brief Read
@@ -177,14 +177,25 @@ void LynxMotorNode::executeUpdateAction(const std::shared_ptr<GoalHandleUpdate> 
 
   RCLCPP_INFO(this->get_logger(), "Executing goal");
 
+  for (auto & driver : drivers_)
+  {
+    driver.updateReset();
+
+    // Send Boot request
+    RCLCPP_INFO(this->get_logger(), "Send boot request to %s", driver.getJointName().c_str());
+    driver.sendBootRequest();
+  }
+
+  // Allow time for Lynx to enter bootloader
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
   // Update each driver sequentially
   for (auto & driver : drivers_)
   {
     last_progress = 0.0f;
+    counter = 0;
 
-    // Reset update variables
-    driver.updateReset();
-
+    RCLCPP_INFO(this->get_logger(), "Send alive check to %s", driver.getJointName().c_str());
     // Wait for Lynx Alive response
     do {
       // Exit if action is cancelled
@@ -192,57 +203,49 @@ void LynxMotorNode::executeUpdateAction(const std::shared_ptr<GoalHandleUpdate> 
         goal_handle->canceled(result);
         RCLCPP_INFO(this->get_logger(), "Goal canceled while updating %s", driver.getJointName().c_str());
         return;
-      }
-
-      // Send Boot request
-      RCLCPP_INFO(this->get_logger(), "Send boot request to %s", driver.getJointName().c_str());
-      driver.sendBootRequest();
-
-      // Allow time for Lynx to enter bootloader
-      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+      }      
 
       // Send alive check
-      RCLCPP_INFO(this->get_logger(), "Send alive check to %s", driver.getJointName().c_str());
       driver.sendBootAliveCheck();
 
-      std::this_thread::sleep_for(std::chrono::milliseconds(400));
-      counter++;
-    } while (!driver.tryGetUpdateAlive() && counter < ALIVE_CHECK_ATTEMPTS);
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    } while (!driver.tryGetUpdateAlive() && counter++ < ALIVE_CHECK_ATTEMPTS);
 
-    // Lynx did not respond in time
-    if (counter == ALIVE_CHECK_ATTEMPTS)
+    // Lynx responded
+    if (counter < ALIVE_CHECK_ATTEMPTS)
+    {
+      RCLCPP_INFO(this->get_logger(), "Driver %s is in bootloader", driver.getJointName().c_str());
+
+      do {
+        // Exit if action is cancelled
+        if (goal_handle->is_canceling()) {
+          goal_handle->canceled(result);
+          RCLCPP_INFO(this->get_logger(), "Goal canceled while updating %s", driver.getJointName().c_str());
+          return;
+        }
+
+        // Run an iteration of the update process
+        progress = driver.updateApp();
+
+        // Report progress as feedback
+        if (progress - last_progress >= 0.01f)
+        {
+          feedback->progress.at(i) = std::round(progress * 100);
+          goal_handle->publish_feedback(feedback);
+          last_progress = progress;
+        }
+      } while (progress < 1.0f);
+      result->success.at(i) = true;
+    }
+    else // Lynx did not respond in time
     {
       RCLCPP_INFO(this->get_logger(), "Driver %s is unresponsive, skipping", driver.getJointName().c_str());
-      continue;
+      result->success.at(i) = false;
     }
 
-    RCLCPP_INFO(this->get_logger(), "Driver %s is in bootloader", driver.getJointName().c_str());
-
-    do {
-      // Exit if action is cancelled
-      if (goal_handle->is_canceling()) {
-        goal_handle->canceled(result);
-        RCLCPP_INFO(this->get_logger(), "Goal canceled while updating %s", driver.getJointName().c_str());
-        return;
-      }
-
-      // Run an iteration of the update process
-      progress = driver.updateApp();
-
-      // Report progress as feedback
-      if (progress - last_progress >= 0.01f)
-      {
-        feedback->progress.at(i) = std::round(progress * 100);
-        goal_handle->publish_feedback(feedback);
-        last_progress = progress;
-      }
-    } while (progress < 1.0f);
-
-    // Send 100% on success
+    // Send 100% on last feedback message
     feedback->progress.at(i) = 100.0;
-    goal_handle->publish_feedback(feedback);
-
-    result->success.at(i) = true;
+    goal_handle->publish_feedback(feedback);    
 
     i++;
   }

--- a/clearpath_motor_drivers/lynx_motor_driver/src/update_action.cpp
+++ b/clearpath_motor_drivers/lynx_motor_driver/src/update_action.cpp
@@ -203,7 +203,7 @@ void LynxMotorNode::executeUpdateAction(const std::shared_ptr<GoalHandleUpdate> 
         goal_handle->canceled(result);
         RCLCPP_INFO(this->get_logger(), "Goal canceled while updating %s", driver.getJointName().c_str());
         return;
-      }      
+      }
 
       // Send alive check
       driver.sendBootAliveCheck();

--- a/clearpath_motor_drivers/lynx_motor_driver/src/update_action.cpp
+++ b/clearpath_motor_drivers/lynx_motor_driver/src/update_action.cpp
@@ -111,8 +111,8 @@ rclcpp_action::GoalResponse LynxMotorNode::handleUpdateGoal(
     filename = dir / folder / file;
   }
   
-  RCLCPP_INFO(this->get_logger(), "Uploading file %s", filename.c_str());
   app = readBinaryFile(filename);
+  RCLCPP_INFO(this->get_logger(), "Uploading file %s len %ld", filename.c_str(), app.size());
   // Copy binary to each driver
   for (auto & driver : drivers_)
   {
@@ -175,17 +175,20 @@ void LynxMotorNode::executeUpdateAction(const std::shared_ptr<GoalHandleUpdate> 
 
   RCLCPP_INFO(this->get_logger(), "Executing goal");
 
+  for (auto & driver : drivers_)
+  {
+    // Send Boot request to each driver
+    RCLCPP_INFO(this->get_logger(), "Send boot request to %s", driver.getJointName().c_str());
+    driver.sendBootRequest();
+  }
+
+  // Allow time for Lynx to enter bootloader
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
   // Update each driver sequentially
   for (auto & driver : drivers_)
   {
     last_progress = 0.0f;
-
-    // Send Boot request
-    RCLCPP_INFO(this->get_logger(), "Send boot request to %s", driver.getJointName().c_str());
-    driver.sendBootRequest();
-
-    // Allow time for Lynx to enter bootloader
-    std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
     RCLCPP_INFO(this->get_logger(), "Send alive check to %s", driver.getJointName().c_str());
     driver.sendBootAliveCheck();
@@ -203,6 +206,8 @@ void LynxMotorNode::executeUpdateAction(const std::shared_ptr<GoalHandleUpdate> 
     } while (!driver.tryGetUpdateAlive());
 
     RCLCPP_INFO(this->get_logger(), "Driver %s is in bootloader", driver.getJointName().c_str());
+
+    driver.getUpdateAck();
 
     do {
       // Exit if action is cancelled

--- a/clearpath_motor_drivers/lynx_motor_driver/src/update_action.cpp
+++ b/clearpath_motor_drivers/lynx_motor_driver/src/update_action.cpp
@@ -207,8 +207,6 @@ void LynxMotorNode::executeUpdateAction(const std::shared_ptr<GoalHandleUpdate> 
 
     RCLCPP_INFO(this->get_logger(), "Driver %s is in bootloader", driver.getJointName().c_str());
 
-    driver.getUpdateAck();
-
     do {
       // Exit if action is cancelled
       if (goal_handle->is_canceling()) {

--- a/clearpath_motor_drivers/lynx_motor_driver/src/update_action.cpp
+++ b/clearpath_motor_drivers/lynx_motor_driver/src/update_action.cpp
@@ -177,6 +177,8 @@ void LynxMotorNode::executeUpdateAction(const std::shared_ptr<GoalHandleUpdate> 
 
   for (auto & driver : drivers_)
   {
+    // Reset update variables
+    driver.updateReset();
     // Send Boot request to each driver
     RCLCPP_INFO(this->get_logger(), "Send boot request to %s", driver.getJointName().c_str());
     driver.sendBootRequest();


### PR DESCRIPTION
- Expect packet counter in ACK message
- Resend packets when ACK counter is mismatched
- Skip unresponsive units
