### PR TITLE
A300 lighting fixes

### DIFF
--- a/clearpath_hardware_interfaces/include/clearpath_hardware_interfaces/lighting/color.hpp
+++ b/clearpath_hardware_interfaces/include/clearpath_hardware_interfaces/lighting/color.hpp
@@ -72,6 +72,7 @@ static const hsv_t COLOR_GREEN = hsv_t(120.0, 100.0, 25.0);
 static const hsv_t COLOR_GREEN_DIM = hsv_t(120.0, 100.0, 12.5);
 static const hsv_t COLOR_YELLOW = hsv_t(60.0, 100.0, 25.0);
 static const hsv_t COLOR_ORANGE = hsv_t(30.0, 100.0, 25.0);
+static const hsv_t COLOR_ORANGE_DARK = hsv_t(30.0, 100.0, 1.0);
 static const hsv_t COLOR_WHITE = hsv_t(0.0, 0.0, 25.0);
 static const hsv_t COLOR_WHITE_DIM = hsv_t(0.0, 0.0, 12.5);
 static const hsv_t COLOR_BLACK = hsv_t(0.0, 0.0, 0.0);

--- a/clearpath_hardware_interfaces/include/clearpath_hardware_interfaces/lighting/lighting.hpp
+++ b/clearpath_hardware_interfaces/include/clearpath_hardware_interfaces/lighting/lighting.hpp
@@ -78,8 +78,8 @@ public:
     ShorePower,
     Charged,
     Charging,
-    Stopped,
     NeedsReset,
+    Stopped,
     LowBattery,
     Driving,
     Idle
@@ -99,7 +99,6 @@ private:
   void startUserTimeoutTimer();
 
   void cmdLightsCallback(const clearpath_platform_msgs::msg::Lights::SharedPtr msg);
-  void statusCallback(const clearpath_platform_msgs::msg::Status::SharedPtr msg);
   void powerCallback(const clearpath_platform_msgs::msg::Power::SharedPtr msg);
   void stopStatusCallback(const clearpath_platform_msgs::msg::StopStatus::SharedPtr msg);
   void batteryStateCallback(const sensor_msgs::msg::BatteryState::SharedPtr msg);
@@ -130,7 +129,6 @@ private:
 
   // Messages
   clearpath_platform_msgs::msg::Lights lights_msg_;
-  clearpath_platform_msgs::msg::Status status_msg_;
   clearpath_platform_msgs::msg::Power power_msg_;
   clearpath_platform_msgs::msg::StopStatus stop_status_msg_;
   sensor_msgs::msg::BatteryState battery_state_msg_;

--- a/clearpath_hardware_interfaces/src/lighting/lighting.cpp
+++ b/clearpath_hardware_interfaces/src/lighting/lighting.cpp
@@ -108,8 +108,8 @@ Lighting::Lighting()
       MS_TO_STEPS(1000), 0.5)},
 
     {State::NeedsReset, BlinkSequence(
-      Sequence::fillLightingState(COLOR_ORANGE, platform_),
-      Sequence::fillLightingState(COLOR_RED, platform_),
+      Sequence::fillOppositeCornerLightingState(COLOR_RED, COLOR_BLACK, platform_),
+      Sequence::fillOppositeCornerLightingState(COLOR_BLACK, COLOR_RED, platform_),
       MS_TO_STEPS(2000), 0.5)},
     
     {State::MotorOverheated, PulseSequence(
@@ -123,7 +123,7 @@ Lighting::Lighting()
     {State::LowBattery, PulseSequence(
       Sequence::fillLightingState(COLOR_ORANGE, platform_),
       Sequence::fillLightingState(COLOR_BLACK, platform_),
-      MS_TO_STEPS(4000))},
+      MS_TO_STEPS(8000))},
 
     {State::Driving, SolidSequence(
       Sequence::fillFrontRearLightingState(COLOR_WHITE, COLOR_RED, platform_))},
@@ -133,6 +133,11 @@ Lighting::Lighting()
   };
 
   current_sequence_ = lighting_sequence_.at(state_);
+
+  // Initial good battery message values until we receive the first message
+  battery_state_msg_.percentage = 1.0f;
+  battery_state_msg_.power_supply_health = sensor_msgs::msg::BatteryState::POWER_SUPPLY_HEALTH_GOOD;
+  battery_state_msg_.power_supply_status = sensor_msgs::msg::BatteryState::POWER_SUPPLY_STATUS_DISCHARGING;
 
   // Initialize ROS2 components
   initializePublishers();
@@ -210,12 +215,6 @@ void Lighting::initializeSubscribers()
     "platform/cmd_lights",
     rclcpp::SystemDefaultsQoS(),
     std::bind(&Lighting::cmdLightsCallback, this, std::placeholders::_1));
-
-  // MCU status
-  status_sub_ = this->create_subscription<clearpath_platform_msgs::msg::Status>(
-    "platform/mcu/status",
-    rclcpp::SensorDataQoS(),
-    std::bind(&Lighting::statusCallback, this, std::placeholders::_1));
 
   // MCU power status
   power_sub_ = this->create_subscription<clearpath_platform_msgs::msg::Power>(
@@ -314,14 +313,6 @@ void Lighting::cmdLightsCallback(const clearpath_platform_msgs::msg::Lights::Sha
 
   // Publish if allowed
   cmd_lights_pub_->publish(*msg);
-}
-
-/**
- * @brief MCU status callback
- */
-void Lighting::statusCallback(const clearpath_platform_msgs::msg::Status::SharedPtr msg)
-{
-  status_msg_ = *msg;
 }
 
 /**

--- a/clearpath_hardware_interfaces/src/lighting/lighting.cpp
+++ b/clearpath_hardware_interfaces/src/lighting/lighting.cpp
@@ -122,8 +122,8 @@ Lighting::Lighting()
 
     {State::LowBattery, PulseSequence(
       Sequence::fillLightingState(COLOR_ORANGE, platform_),
-      Sequence::fillLightingState(COLOR_BLACK, platform_),
-      MS_TO_STEPS(8000))},
+      Sequence::fillLightingState(COLOR_ORANGE_DARK, platform_),
+      MS_TO_STEPS(4000))},
 
     {State::Driving, SolidSequence(
       Sequence::fillFrontRearLightingState(COLOR_WHITE, COLOR_RED, platform_))},


### PR DESCRIPTION
- Removed status message subscriber
- Set NeedsReset to be higher priority than Stopped
- Updated NeedsReset sequence
- Set initial battery state values
- Changed low battery sequence