### PR TITLE
Remove references to `hardware_interface/visibility_control.h`

### DIFF
--- a/clearpath_hardware_interfaces/include/clearpath_hardware_interfaces/a200/hardware.hpp
+++ b/clearpath_hardware_interfaces/include/clearpath_hardware_interfaces/a200/hardware.hpp
@@ -10,7 +10,6 @@
 #include "hardware_interface/hardware_info.hpp"
 #include "hardware_interface/system_interface.hpp"
 #include "hardware_interface/types/hardware_interface_return_values.hpp"
-#include "hardware_interface/visibility_control.h"
 #include "rclcpp/macros.hpp"
 
 #include "rclcpp/rclcpp.hpp"
@@ -20,6 +19,7 @@
 
 #include "clearpath_hardware_interfaces/a200/horizon_legacy/horizon_legacy_wrapper.h"
 #include "clearpath_hardware_interfaces/a200/status.hpp"
+#include "clearpath_hardware_interfaces/visibility_control.h"
 
 #include "clearpath_platform_msgs/msg/power.hpp"
 #include "clearpath_platform_msgs/msg/status.hpp"

--- a/clearpath_hardware_interfaces/include/clearpath_hardware_interfaces/diff_drive/hardware.hpp
+++ b/clearpath_hardware_interfaces/include/clearpath_hardware_interfaces/diff_drive/hardware.hpp
@@ -44,9 +44,9 @@
 #include "hardware_interface/hardware_info.hpp"
 #include "hardware_interface/system_interface.hpp"
 #include "hardware_interface/types/hardware_interface_return_values.hpp"
-#include "hardware_interface/visibility_control.h"
 
 #include "clearpath_hardware_interfaces/diff_drive/hardware_interface.hpp"
+#include "clearpath_hardware_interfaces/visibility_control.h"
 
 
 namespace clearpath_hardware_interfaces

--- a/clearpath_hardware_interfaces/include/clearpath_hardware_interfaces/lynx/hardware.hpp
+++ b/clearpath_hardware_interfaces/include/clearpath_hardware_interfaces/lynx/hardware.hpp
@@ -44,9 +44,9 @@
 #include "hardware_interface/system_interface.hpp"
 #include "hardware_interface/types/hardware_interface_return_values.hpp"
 #include "hardware_interface/types/hardware_interface_type_values.hpp"
-#include "hardware_interface/visibility_control.h"
 
 #include "clearpath_hardware_interfaces/lynx/hardware_interface.hpp"
+#include "clearpath_hardware_interfaces/visibility_control.h"
 
 
 namespace clearpath_hardware_interfaces

--- a/clearpath_hardware_interfaces/include/clearpath_hardware_interfaces/puma/hardware.hpp
+++ b/clearpath_hardware_interfaces/include/clearpath_hardware_interfaces/puma/hardware.hpp
@@ -43,9 +43,9 @@
 #include "hardware_interface/system_interface.hpp"
 #include "hardware_interface/types/hardware_interface_return_values.hpp"
 #include "hardware_interface/types/hardware_interface_type_values.hpp"
-#include "hardware_interface/visibility_control.h"
 
 #include "clearpath_hardware_interfaces/puma/hardware_interface.hpp"
+#include "clearpath_hardware_interfaces/visibility_control.h"
 
 
 namespace clearpath_hardware_interfaces

--- a/clearpath_hardware_interfaces/include/clearpath_hardware_interfaces/visibility_control.h
+++ b/clearpath_hardware_interfaces/include/clearpath_hardware_interfaces/visibility_control.h
@@ -1,0 +1,49 @@
+// Copyright 2017 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef HARDWARE_INTERFACE__VISIBILITY_CONTROL_H_
+#define HARDWARE_INTERFACE__VISIBILITY_CONTROL_H_
+
+// This logic was borrowed (then namespaced) from the examples on the gcc wiki:
+//     https://gcc.gnu.org/wiki/Visibility
+
+#if defined _WIN32 || defined __CYGWIN__
+#ifdef __GNUC__
+#define HARDWARE_INTERFACE_EXPORT __attribute__((dllexport))
+#define HARDWARE_INTERFACE_IMPORT __attribute__((dllimport))
+#else
+#define HARDWARE_INTERFACE_EXPORT __declspec(dllexport)
+#define HARDWARE_INTERFACE_IMPORT __declspec(dllimport)
+#endif
+#ifdef HARDWARE_INTERFACE_BUILDING_DLL
+#define HARDWARE_INTERFACE_PUBLIC HARDWARE_INTERFACE_EXPORT
+#else
+#define HARDWARE_INTERFACE_PUBLIC HARDWARE_INTERFACE_IMPORT
+#endif
+#define HARDWARE_INTERFACE_PUBLIC_TYPE HARDWARE_INTERFACE_PUBLIC
+#define HARDWARE_INTERFACE_LOCAL
+#else
+#define HARDWARE_INTERFACE_EXPORT __attribute__((visibility("default")))
+#define HARDWARE_INTERFACE_IMPORT
+#if __GNUC__ >= 4
+#define HARDWARE_INTERFACE_PUBLIC __attribute__((visibility("default")))
+#define HARDWARE_INTERFACE_LOCAL __attribute__((visibility("hidden")))
+#else
+#define HARDWARE_INTERFACE_PUBLIC
+#define HARDWARE_INTERFACE_LOCAL
+#endif
+#define HARDWARE_INTERFACE_PUBLIC_TYPE
+#endif
+
+#endif  // HARDWARE_INTERFACE__VISIBILITY_CONTROL_H_

--- a/clearpath_hardware_interfaces/include/clearpath_hardware_interfaces/w200/hardware.hpp
+++ b/clearpath_hardware_interfaces/include/clearpath_hardware_interfaces/w200/hardware.hpp
@@ -44,9 +44,9 @@
 #include "hardware_interface/hardware_info.hpp"
 #include "hardware_interface/system_interface.hpp"
 #include "hardware_interface/types/hardware_interface_return_values.hpp"
-#include "hardware_interface/visibility_control.h"
 
 #include "clearpath_hardware_interfaces/w200/hardware_interface.hpp"
+#include "clearpath_hardware_interfaces/visibility_control.h"
 
 
 namespace clearpath_hardware_interfaces


### PR DESCRIPTION
It appears ROS Control has removed `visibility_control.h` from the latest debians of `hardware_interface` leading to build errors on Jazzy.

Copying the old file contents into this package, and updating the include paths fixes the problem, though it's perhaps not the most elegant solution.