### PR TITLE
VCAN fix for Lynx remote request issue

### DIFF
--- a/clearpath_robot/scripts/vcan
+++ b/clearpath_robot/scripts/vcan
@@ -59,13 +59,20 @@ echo "Device: $dev";
 echo "Virtual CAN: $vcan";
 echo "Baud Rate: $baud";
 
-socat udp4-datagram:192.168.131.2:$port,bind=:$port,range=192.168.131.1/24 pty,link=$dev &
+# Bind to UDP4 socket, create a new pty device and bridge them
+socat udp4-datagram:192.168.131.2:$port,bind=:$port,range=192.168.131.1/24 pty,link=$dev,echo=0 &
 sleep 1
 
+# Create virtual serial CAN interface using the pty serial device
 slcand -o -c -F -$baud $dev $vcan &
 sleep 1
 
+# Increase Tx queue length
 ip link set $vcan txqueuelen 100
 sleep 1
 
+# Bring vcan interface up
 ip link set $vcan up
+
+# Send a message to the virtual CAN interface to enable echoing on the serial device
+cangen $vcan -n 1

--- a/clearpath_robot/scripts/vcan
+++ b/clearpath_robot/scripts/vcan
@@ -75,4 +75,4 @@ sleep 1
 ip link set $vcan up
 
 # Send a message to the virtual CAN interface to enable echoing on the serial device
-cangen $vcan -n 1
+cangen $vcan -n 1 -L 0 -I 0


### PR DESCRIPTION
The current `socat` command caused UDP packets sent to the PC from the MCU to be echo'd in the serial device, and were then sent right back to the MCU. This caused the remote request issue on the Lynx controllers, as those CAN messages were configured for Transmit, and the controllers do not expect to receive the same message back.

Fix:
- Set echo=0 on the pty serial device while slcand is setting up to disable echoing while we set up `slcand`
- After setup, `cangen` a single message to re-enable echoing on the serial device, effectively starting up the vcan interface