### PR TITLE
Added Lynx motor driver diagnostics

### DIFF
--- a/clearpath_diagnostics/config/diagnostic_aggregator.yaml
+++ b/clearpath_diagnostics/config/diagnostic_aggregator.yaml
@@ -21,6 +21,10 @@ diagnostic_aggregator:
           type: diagnostic_aggregator/GenericAnalyzer
           path: Lighting
           contains: [ 'Light' ]
+        motor_drivers:
+          type: diagnostic_aggregator/GenericAnalyzer
+          path: Motor Drivers
+          contains: [ 'Lynx' ]
     sensors:
       type: diagnostic_aggregator/AnalyzerGroup
       path: Sensors

--- a/clearpath_generator_robot/clearpath_generator_robot/launch/generator.py
+++ b/clearpath_generator_robot/clearpath_generator_robot/launch/generator.py
@@ -286,6 +286,7 @@ class RobotLaunchGenerator(LaunchGenerator):
           parameters=[os.path.join(self.platform_params_path, 'control.yaml')],
           name='lynx_control',
           namespace=self.namespace,
+          remappings=[('/diagnostics', 'diagnostics'),],
         )
 
         # ROS2 socketcan bridges

--- a/clearpath_motor_drivers/lynx_motor_driver/CMakeLists.txt
+++ b/clearpath_motor_drivers/lynx_motor_driver/CMakeLists.txt
@@ -19,6 +19,7 @@ find_package(ament_index_cpp REQUIRED)
 find_package(can_msgs REQUIRED)
 find_package(clearpath_motor_msgs REQUIRED)
 find_package(clearpath_ros2_socketcan_interface REQUIRED)
+find_package(diagnostic_updater REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_action REQUIRED)
 find_package(sensor_msgs REQUIRED)
@@ -40,6 +41,7 @@ set(DEPENDENCIES
   can_msgs
   clearpath_motor_msgs
   clearpath_ros2_socketcan_interface
+  diagnostic_updater
   rclcpp
   rclcpp_action
   sensor_msgs

--- a/clearpath_motor_drivers/lynx_motor_driver/include/lynx_motor_driver/lynx_motor_driver.hpp
+++ b/clearpath_motor_drivers/lynx_motor_driver/include/lynx_motor_driver/lynx_motor_driver.hpp
@@ -29,6 +29,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
 #include <mutex>
 
 #include "clearpath_ros2_socketcan_interface/socketcan_interface.hpp"
+#include "diagnostic_updater/update_functions.hpp"
 
 #include "lynx_motor_driver/message.hpp"
 
@@ -37,6 +38,9 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
 #include "clearpath_motor_msgs/msg/lynx_status.hpp"
 #include "clearpath_motor_msgs/msg/lynx_system_protection.hpp"
 #include <memory>
+
+// Used to smooth out voltage/current/velocity data for diagnostics since it is infrequently updated
+#define DIAGNOSTICS_LOW_PASS 0.9
 
 namespace lynx_motor_driver
 {
@@ -155,6 +159,9 @@ public:
   void send(const uint32_t id);
   void send(const uint32_t id, uint8_t * data, uint8_t length);
 
+  // Diagnostics
+  void runFreqStatus(diagnostic_updater::DiagnosticStatusWrapper & stat);
+
 private:
   // Driver variables
   int64_t can_id_;
@@ -164,6 +171,7 @@ private:
   bool debug_;
   float offset_;
   uint16_t iteration_;
+  float current_filtered, voltage_filtered, velocity_filtered;
 
   // CAN interface
   std::shared_ptr<clearpath_ros2_socketcan_interface::SocketCANInterface> can_interface_;
@@ -186,6 +194,10 @@ private:
 
   // Get COBID from message ID
   uint32_t getCOBID(const uint32_t id) const;
+
+  // Frequency Status for diagnostics
+  std::shared_ptr<double> can_feedback_rate_; // Shared ptr prevents copy errors of FrequencyStatus
+  std::shared_ptr<diagnostic_updater::FrequencyStatus> can_feedback_freq_status_;
 };
 
 }  // namespace lynx_motor_driver

--- a/clearpath_motor_drivers/lynx_motor_driver/include/lynx_motor_driver/lynx_motor_node.hpp
+++ b/clearpath_motor_drivers/lynx_motor_driver/include/lynx_motor_driver/lynx_motor_node.hpp
@@ -24,6 +24,9 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
 #ifndef LYNX_MOTOR_DRIVER__LYNX_MOTOR_NODE_H
 #define LYNX_MOTOR_DRIVER__LYNX_MOTOR_NODE_H
 
+#include <regex>
+
+#include "diagnostic_updater/diagnostic_updater.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_action/rclcpp_action.hpp"
 #include "std_msgs/msg/float64.hpp"
@@ -78,6 +81,9 @@ private:
   using GoalHandleCalibrate = rclcpp_action::ServerGoalHandle<Calibrate>;
   using Update = clearpath_motor_msgs::action::LynxUpdate;
   using GoalHandleUpdate = rclcpp_action::ServerGoalHandle<Update>;
+  using LynxStatus = clearpath_motor_msgs::msg::LynxStatus;
+  using LynxSystemProtection = clearpath_motor_msgs::msg::LynxSystemProtection;
+  using DiagnosticStatusWrapper = diagnostic_updater::DiagnosticStatusWrapper;
 
   // Drivers
   std::vector<lynx_motor_driver::LynxMotorDriver> drivers_;
@@ -95,12 +101,13 @@ private:
   std::vector<std::string> joint_names_;
   std::vector<int64_t> joint_can_ids_;
   std::vector<int64_t> joint_directions_;
+  std::string firmware_version_expected_;
 
   // Messages
   clearpath_motor_msgs::msg::LynxMultiStatus status_msg_;
   clearpath_motor_msgs::msg::LynxMultiFeedback feedback_msg_;
   clearpath_motor_msgs::msg::LynxMultiDebug debug_msg_;
-  clearpath_motor_msgs::msg::LynxSystemProtection system_protection_msg_;
+  LynxSystemProtection system_protection_msg_;
 
   // Action servers
   rclcpp_action::Server<Calibrate>::SharedPtr calibrate_action_server_;
@@ -110,7 +117,7 @@ private:
   rclcpp::Publisher<clearpath_motor_msgs::msg::LynxMultiStatus>::SharedPtr status_pub_;
   rclcpp::Publisher<clearpath_motor_msgs::msg::LynxMultiFeedback>::SharedPtr feedback_pub_;
   rclcpp::Publisher<clearpath_motor_msgs::msg::LynxMultiDebug>::SharedPtr debug_pub_;
-  rclcpp::Publisher<clearpath_motor_msgs::msg::LynxSystemProtection>::SharedPtr system_protection_pub_;
+  rclcpp::Publisher<LynxSystemProtection>::SharedPtr system_protection_pub_;
 
   // Subscribers
   rclcpp::Subscription<sensor_msgs::msg::JointState>::SharedPtr cmd_sub_;
@@ -121,6 +128,49 @@ private:
   rclcpp::TimerBase::SharedPtr debug_timer_;
   rclcpp::TimerBase::SharedPtr protection_timer_;
 
+  // Diagnostic Updater
+  diagnostic_updater::Updater updater_;
+
+  // Diagnostic Labels
+  const std::map<uint8_t, std::string> STATUS_FLAG_LABELS_ = {
+    {LynxStatus::STATUS_FLAG_ADC_CALIBRATED, "ADC Calibrated"},
+    {LynxStatus::STATUS_FLAG_ROTOR_CALIBRATED, "Rotor Calibrated"},
+    {LynxStatus::STATUS_FLAG_CALIBRATION_REQUESTED, "Calibration Requested"},
+    {LynxStatus::STATUS_FLAG_CALIBRATION_CANCELLED, "Calibration Cancelled"},
+    {LynxStatus::STATUS_FLAG_FIRST_VEL_RECEIVED, "First Velocity Received"},
+    {LynxStatus::STATUS_FLAG_ESTOPPED, "E-stopped"},
+  };
+
+  const std::map<uint8_t, std::string> ERROR_FLAG_LABELS_ = {
+    {LynxStatus::ERROR_FLAG_NOT_CALIBRATED, "Not Calibrated"},
+    {LynxStatus::ERROR_FLAG_MOTOR_FAULT, "Motor Fault"},
+    {LynxStatus::ERROR_FLAG_MOTOR_STALLING, "Motor Stalling"},
+    {LynxStatus::ERROR_FLAG_MOTOR_THERMISTOR, "Motor Thermistor Not Detected"},
+    {LynxStatus::ERROR_FLAG_PCB_THERMISTOR, "PCB Thermistor Not Detected"},
+    {LynxStatus::ERROR_FLAG_PHASE, "Phase Error"},
+    {LynxStatus::ERROR_FLAG_PHASE_A, "Phase A Disconnected"},
+    {LynxStatus::ERROR_FLAG_PHASE_B, "Phase B Disconnected"},
+    {LynxStatus::ERROR_FLAG_PHASE_C, "Phase C Disconnected"},
+    {LynxStatus::ERROR_FLAG_ENCODER_POWER, "Encoder Power Error"},
+    {LynxStatus::ERROR_FLAG_ENCODER_INDEX, "Encoder Index Not Detected"},
+    {LynxStatus::ERROR_FLAG_ENCODER_OUTPUT_A, "Encoder Output A Error"},
+    {LynxStatus::ERROR_FLAG_ENCODER_OUTPUT_B, "Encoder Output B Error"},
+  };
+
+  const std::map<uint8_t, std::string> LYNX_PROTECTION_LABELS_ = {
+    {LynxSystemProtection::NORMAL, "Normal"},
+    {LynxSystemProtection::THROTTLED, "Throttled"},
+    {LynxSystemProtection::OVERHEATED, "Overheated"},
+    {LynxSystemProtection::ERROR, "Error"},
+  };
+
+  const std::map<uint8_t, std::string> LYNX_MOTOR_LABELS_ = {
+    {LynxSystemProtection::A300_MOTOR_FRONT_LEFT, "Front Left"},
+    {LynxSystemProtection::A300_MOTOR_FRONT_RIGHT, "Front Right"},
+    {LynxSystemProtection::A300_MOTOR_REAR_LEFT, "Rear Left"},
+    {LynxSystemProtection::A300_MOTOR_REAR_RIGHT, "Rear Right"},
+  };
+
   // System Protection
   void updateSystemState();
   void sendSystemState();
@@ -128,6 +178,10 @@ private:
 
   // Debugging
   void startDebug();
+
+  // Diagnostic Tasks
+  void driverDiagnostic(diagnostic_updater::DiagnosticStatusWrapper & stat, int i);
+  void protectionDiagnostic(diagnostic_updater::DiagnosticStatusWrapper & stat);
 
   // Calibrate action
   rclcpp_action::GoalResponse handleCalibrateGoal(
@@ -147,6 +201,10 @@ private:
     const std::shared_ptr<GoalHandleUpdate> goal_handle);
   void handleUpdateAccepted(const std::shared_ptr<GoalHandleUpdate> goal_handle);
   void executeUpdateAction(const std::shared_ptr<GoalHandleUpdate> goal_handle);
+  std::string getDefaultFirmware();
+
+  // Fimware version check
+  std::string parseFirmwareVersion(std::string filename);
 };
 
 #endif // LYNX_MOTOR_DRIVER__LYNX_MOTOR_NODE_H

--- a/clearpath_motor_drivers/lynx_motor_driver/package.xml
+++ b/clearpath_motor_drivers/lynx_motor_driver/package.xml
@@ -12,6 +12,7 @@
   <depend>can_msgs</depend>
   <depend version_gte="2.1.0">clearpath_motor_msgs</depend>
   <depend>clearpath_ros2_socketcan_interface</depend>
+  <depend>diagnostic_updater</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_action</depend>
   <depend>ros2_socketcan</depend>

--- a/clearpath_motor_drivers/lynx_motor_driver/src/lynx_motor_driver.cpp
+++ b/clearpath_motor_drivers/lynx_motor_driver/src/lynx_motor_driver.cpp
@@ -35,7 +35,7 @@ namespace lynx_motor_driver
 
 /**
  * @brief Construct a new Lynx Motor Driver object
- * 
+ *
  * @param can_id CAN ID
  * @param joint_name Joint name
  * @param direction Direction of rotation
@@ -87,7 +87,7 @@ LynxMotorDriver::LynxMotorDriver(const int64_t& can_id,
 
 /**
  * @brief Process a received CAN message
- * 
+ *
  * @param received_msg Message reference
  * @return true if processed by this driver.
  * @return false otherwise.
@@ -145,13 +145,13 @@ bool LynxMotorDriver::processMessage(const Message& received_msg)
           uint32_t version = std::get<uint32_t>(received_msg.getDataAsIndexedUint32());
           bool debug = (version & 0xFF);
 
-          status_msg_.firmware_version = 
+          status_msg_.firmware_version =
             std::to_string((version >> 24) & 0xFF) +
             "." +
             std::to_string((version >> 16) & 0xFF) +
             "." +
             std::to_string((version >> 8) & 0xFF);
-          
+
           if (debug)
           {
             status_msg_.firmware_version += " Debug";
@@ -342,7 +342,7 @@ bool LynxMotorDriver::processMessage(const Message& received_msg)
 
 /**
  * @brief Check if debug message has been filled
- * 
+ *
  * @return true if message is ready.
  * @return false otherwise.
  */
@@ -365,7 +365,7 @@ bool LynxMotorDriver::debugMessageReady()
 
 /**
  * @brief Check if feedback message has been filled
- * 
+ *
  * @return true if message is ready.
  * @return false otherwise.
  */
@@ -388,7 +388,7 @@ bool LynxMotorDriver::feedbackMessageReady()
 
 /**
  * @brief Check if status message has been filled
- * 
+ *
  * @return true if message is ready.
  * @return false otherwise.
  */
@@ -411,8 +411,8 @@ bool LynxMotorDriver::statusMessageReady()
 
 /**
  * @brief Get the debug message
- * 
- * @return clearpath_motor_msgs::msg::LynxDebug 
+ *
+ * @return clearpath_motor_msgs::msg::LynxDebug
  */
 clearpath_motor_msgs::msg::LynxDebug LynxMotorDriver::getDebugMessage()
 {
@@ -426,8 +426,8 @@ clearpath_motor_msgs::msg::LynxDebug LynxMotorDriver::getDebugMessage()
 
 /**
  * @brief Get the feedback message
- * 
- * @return clearpath_motor_msgs::msg::LynxFeedback 
+ *
+ * @return clearpath_motor_msgs::msg::LynxFeedback
  */
 clearpath_motor_msgs::msg::LynxFeedback LynxMotorDriver::getFeedbackMessage()
 {
@@ -441,8 +441,8 @@ clearpath_motor_msgs::msg::LynxFeedback LynxMotorDriver::getFeedbackMessage()
 
 /**
  * @brief Get the status message
- * 
- * @return clearpath_motor_msgs::msg::LynxStatus 
+ *
+ * @return clearpath_motor_msgs::msg::LynxStatus
  */
 clearpath_motor_msgs::msg::LynxStatus LynxMotorDriver::getStatusMessage()
 {
@@ -456,7 +456,7 @@ clearpath_motor_msgs::msg::LynxStatus LynxMotorDriver::getStatusMessage()
 
 /**
  * @brief Send a velocity to the driver
- * 
+ *
  * @param velocity Velocity in rad/s
  */
 void LynxMotorDriver::sendVelocity(double velocity)
@@ -466,7 +466,7 @@ void LynxMotorDriver::sendVelocity(double velocity)
 
 /**
  * @brief Send the system protection state to the driver
- * 
+ *
  * @param state System protection state
  */
 void LynxMotorDriver::sendProtectionState(uint8_t state)
@@ -476,7 +476,7 @@ void LynxMotorDriver::sendProtectionState(uint8_t state)
 
 /**
  * @brief Get the driver protection state
- * 
+ *
  * @return uint8_t representing the protection state
  */
 uint8_t LynxMotorDriver::getProtectionState()
@@ -486,7 +486,7 @@ uint8_t LynxMotorDriver::getProtectionState()
 
 /**
  * @brief Send a calibration request to the driver
- * 
+ *
  */
 void LynxMotorDriver::sendCalibrationRequest()
 {
@@ -495,7 +495,7 @@ void LynxMotorDriver::sendCalibrationRequest()
 
 /**
  * @brief Cancel calibration on the driver
- * 
+ *
  */
 void LynxMotorDriver::sendCalibrationCancel()
 {
@@ -504,7 +504,7 @@ void LynxMotorDriver::sendCalibrationCancel()
 
 /**
  * @brief Get the COBID from a message ID and the driver's CAN ID
- * 
+ *
  * @param msg_id message ID
  * @return uint32_t representing the COBID
  */
@@ -515,7 +515,7 @@ uint32_t LynxMotorDriver::getCOBID(const uint32_t msg_id) const
 
 /**
  * @brief Send a message to the driver. Converts from DataT to an 8 byte CAN data array.
- * 
+ *
  * @tparam DataT Data type (Up to 8 bytes long)
  * @param id Message ID
  * @param value Data value
@@ -539,14 +539,14 @@ void LynxMotorDriver::send(const uint32_t id, const DataT value)
   uint8_t data[8] = {0};
   std::memcpy(data, &value, sizeof(DataT));
   std::copy(std::begin(data), std::end(data), std::begin(frame.data));
-  
+
   // Send frame to CAN interface
   can_interface_->send(frame);
 }
 
 /**
  * @brief Send a message to the driver with no data.
- * 
+ *
  * @param id Message ID
  */
 void LynxMotorDriver::send(const uint32_t id)
@@ -556,14 +556,14 @@ void LynxMotorDriver::send(const uint32_t id)
   frame.id = getCOBID(id);
   frame.dlc = 0;
   frame.is_extended = true;
-  
+
   // Send frame to CAN interface
   can_interface_->send(frame);
 }
 
 /**
  * @brief Send a message to the driver with data from a buffer.
- * 
+ *
  * @param id Message ID
  * @param data Data buffer
  * @param length Data buffer length
@@ -587,14 +587,14 @@ void LynxMotorDriver::send(const uint32_t id, uint8_t * data, uint8_t length)
   uint8_t buffer[8] = {0};
   std::memcpy(buffer, data, length);
   std::copy(std::begin(buffer), std::end(buffer), std::begin(frame.data));
-  
+
   // Send frame to CAN interface
   can_interface_->send(frame);
 }
 
 /**
  * @brief Send a boot request to the driver.
- * 
+ *
  */
 void LynxMotorDriver::sendBootRequest()
 {
@@ -603,7 +603,7 @@ void LynxMotorDriver::sendBootRequest()
 
 /**
  * @brief Send a boot alive check to the driver.
- * 
+ *
  */
 void LynxMotorDriver::sendBootAliveCheck()
 {
@@ -621,7 +621,7 @@ void LynxMotorDriver::updateReset()
 
 /**
  * @brief Copy the application to the driver.
- * 
+ *
  * @param app Queue of bytes representing the application
  */
 void LynxMotorDriver::copyApplication(const std::queue<uint8_t> app)
@@ -632,7 +632,7 @@ void LynxMotorDriver::copyApplication(const std::queue<uint8_t> app)
 
 /**
  * @brief Run an iteration of a CAN bootloader update.
- * 
+ *
  * @return float representing update progress as a percentage.
  */
 float LynxMotorDriver::updateApp()
@@ -673,7 +673,7 @@ float LynxMotorDriver::updateApp()
         frame_data[i] = 0x00;
       }
     }
-  
+
     app_count_++;
 
     do
@@ -693,7 +693,7 @@ float LynxMotorDriver::updateApp()
 /**
  * @brief Attempt to acquire the iteration mutex.
  * If acquired, assign the iteration value to the iteration parameter.
- * 
+ *
  * @param iteration Reference to iteration variable.
  * @return true on success.
  * @return false otherwise.
@@ -712,7 +712,7 @@ bool LynxMotorDriver::tryGetIteration(uint16_t & iteration)
 /**
  * @brief Attempt to acquire the offset mutex.
  * If acquired, assign the offset value to the offset parameter.
- * 
+ *
  * @param offset Reference to offset variable.
  * @return true on success.
  * @return false otherwise.
@@ -730,7 +730,7 @@ bool LynxMotorDriver::tryGetOffset(float & offset)
 
 /**
  * @brief Attempt to acquire the update ack mutex.
- * 
+ *
  * @return true if acquired.
  * @return false otherwise.
  */
@@ -747,7 +747,7 @@ bool LynxMotorDriver::tryGetUpdateAck(uint16_t & can_count)
 
 /**
  * @brief Attempt to acquire the update alive mutex.
- * 
+ *
  * @return true if acquired.
  * @return false otherwise.
  */

--- a/clearpath_motor_drivers/lynx_motor_driver/src/lynx_motor_driver.cpp
+++ b/clearpath_motor_drivers/lynx_motor_driver/src/lynx_motor_driver.cpp
@@ -29,6 +29,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
 #include <cstring>
 #include <math.h>
 
+#define CAN_FEEDBACK_RATE 50.0  // Must match the firmware
 
 namespace lynx_motor_driver
 {
@@ -83,6 +84,10 @@ LynxMotorDriver::LynxMotorDriver(const int64_t& can_id,
 
   status_msg_.can_id = getCanID();
   status_msg_.joint_name = getJointName();
+
+  can_feedback_rate_ = std::make_shared<double>(CAN_FEEDBACK_RATE);
+  can_feedback_freq_status_ = std::make_shared<diagnostic_updater::FrequencyStatus>(
+    diagnostic_updater::FrequencyStatusParam(can_feedback_rate_.get(), can_feedback_rate_.get(), 0.1, 5));
 }
 
 /**
@@ -114,18 +119,26 @@ bool LynxMotorDriver::processMessage(const Message& received_msg)
         case Feedback::Fields::Current:
         {
           feedback_msg_.current = data;
+          can_feedback_freq_status_->tick();
+          current_filtered = (current_filtered * DIAGNOSTICS_LOW_PASS) +
+                            (feedback_msg_.current * (1-DIAGNOSTICS_LOW_PASS));
+
           break;
         }
 
         case Feedback::Fields::Voltage:
         {
           feedback_msg_.voltage = data;
+          voltage_filtered = (voltage_filtered * DIAGNOSTICS_LOW_PASS) +
+                            (feedback_msg_.voltage * (1-DIAGNOSTICS_LOW_PASS));
           break;
         }
 
         case Feedback::Fields::Velocity:
         {
           feedback_msg_.velocity = data * direction_;
+          velocity_filtered = (velocity_filtered * DIAGNOSTICS_LOW_PASS) +
+                            (feedback_msg_.velocity * (1-DIAGNOSTICS_LOW_PASS));
           break;
         }
       }
@@ -773,6 +786,22 @@ void LynxMotorDriver::getUpdateAck(uint16_t & can_count)
 void LynxMotorDriver::getUpdateAlive()
 {
   action_mutexes_[Action::Fields::UpdateAlive]->lock();
+}
+
+/**
+ * @brief Runs the frequency diagnostic update to populate the status message
+ */
+void LynxMotorDriver::runFreqStatus(diagnostic_updater::DiagnosticStatusWrapper & stat)
+{
+  can_feedback_freq_status_->run(stat);
+
+  if (stat.level != diagnostic_updater::DiagnosticStatusWrapper::ERROR) {
+    // Error from the frequency status would mean that no messages are being received
+    // therefore return instead of reporting on old data
+    stat.add("Current", current_filtered);
+    stat.add("Voltage", voltage_filtered);
+    stat.add("Velocity", velocity_filtered);
+  }
 }
 
 }  // namespace lynx_motor_driver

--- a/clearpath_motor_drivers/lynx_motor_driver/src/lynx_motor_node.cpp
+++ b/clearpath_motor_drivers/lynx_motor_driver/src/lynx_motor_node.cpp
@@ -26,7 +26,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
 
 /**
  * @brief Construct a new LynxMotorNode object
- * 
+ *
  * @param node_name Node name
  */
 LynxMotorNode::LynxMotorNode(const std::string node_name) :
@@ -129,7 +129,7 @@ LynxMotorNode::LynxMotorNode(const std::string node_name) :
     std::bind(&LynxMotorNode::handleCalibrateGoal, this, std::placeholders::_1, std::placeholders::_2),
     std::bind(&LynxMotorNode::handleCalibrateCancel, this, std::placeholders::_1),
     std::bind(&LynxMotorNode::handleCalibrateAccepted, this, std::placeholders::_1));
-  
+
   update_action_server_ = rclcpp_action::create_server<Update>(
     this,
     "platform/motors/update",
@@ -148,13 +148,13 @@ LynxMotorNode::LynxMotorNode(const std::string node_name) :
   // Start timers
   feedback_timer_ = this->create_wall_timer(
     std::chrono::milliseconds(static_cast<uint64_t>(1000 / feedback_hz_)), std::bind(&LynxMotorNode::runFeedback, this));
-  
+
   status_timer_ = this->create_wall_timer(
     std::chrono::milliseconds(static_cast<uint64_t>(1000 / status_hz_)), std::bind(&LynxMotorNode::runStatus, this));
-  
+
   debug_timer_ = this->create_wall_timer(
     std::chrono::milliseconds(static_cast<uint64_t>(1000 / debug_hz_)), std::bind(&LynxMotorNode::runDebug, this));
-  
+
   protection_timer_ = this->create_wall_timer(
     std::chrono::milliseconds(1000), std::bind(&LynxMotorNode::sendSystemState, this));
 }
@@ -162,7 +162,7 @@ LynxMotorNode::LynxMotorNode(const std::string node_name) :
 
 /**
  * @brief Update MultiDebug message
- * 
+ *
  */
 void LynxMotorNode::updateDebug()
 {
@@ -181,7 +181,7 @@ void LynxMotorNode::updateDebug()
 
 /**
  * @brief Update MultiStatus message
- * 
+ *
  */
 void LynxMotorNode::updateStatus()
 {
@@ -200,7 +200,7 @@ void LynxMotorNode::updateStatus()
 
 /**
  * @brief Update MultiFeedback message
- * 
+ *
  */
 void LynxMotorNode::updateFeedback()
 {
@@ -219,7 +219,7 @@ void LynxMotorNode::updateFeedback()
 
 /**
  * @brief Update debug message, then publish it
- * 
+ *
  */
 void LynxMotorNode::publishDebug()
 {
@@ -229,7 +229,7 @@ void LynxMotorNode::publishDebug()
 
 /**
  * @brief Update feedback message, then publish it
- * 
+ *
  */
 void LynxMotorNode::publishFeedback()
 {
@@ -239,7 +239,7 @@ void LynxMotorNode::publishFeedback()
 
 /**
  * @brief Update status message, then publish it
- * 
+ *
  */
 void LynxMotorNode::publishStatus()
 {
@@ -250,8 +250,8 @@ void LynxMotorNode::publishStatus()
 /**
  * @brief Callback to driver command subscriber.
  * Send commanded velocity to driver with matching joint name
- * 
- * @param msg 
+ *
+ * @param msg
  */
 void LynxMotorNode::cmdCallback(const sensor_msgs::msg::JointState::SharedPtr msg)
 {
@@ -277,8 +277,8 @@ void LynxMotorNode::cmdCallback(const sensor_msgs::msg::JointState::SharedPtr ms
 /**
  * @brief CAN Rx callback.
  * Process message on receive
- * 
- * @param msg 
+ *
+ * @param msg
  */
 void LynxMotorNode::canRxCallback(const can_msgs::msg::Frame::SharedPtr msg)
 {
@@ -296,7 +296,7 @@ void LynxMotorNode::canRxCallback(const can_msgs::msg::Frame::SharedPtr msg)
 /**
  * @brief Feedback timer callback.
  * Publish feedback and update system protection state
- * 
+ *
  */
 void LynxMotorNode::runFeedback()
 {
@@ -312,7 +312,7 @@ void LynxMotorNode::runFeedback()
 /**
  * @brief Status timer callback.
  * Publish status
- * 
+ *
  */
 void LynxMotorNode::runStatus()
 {
@@ -327,7 +327,7 @@ void LynxMotorNode::runStatus()
 /**
  * @brief Debug timer callback.
  * Publish debug if any of the drivers are running debug firmware.
- * 
+ *
  */
 void LynxMotorNode::runDebug()
 {
@@ -356,7 +356,7 @@ void LynxMotorNode::runDebug()
 
 /**
  * @brief Start debug publisher
- * 
+ *
  */
 void LynxMotorNode::startDebug()
 {
@@ -365,6 +365,6 @@ void LynxMotorNode::startDebug()
   debug_pub_ = this->create_publisher<clearpath_motor_msgs::msg::LynxMultiDebug>(
     "platform/motors/debug",
     rclcpp::SensorDataQoS());
-  
+
   debugging_ = true;
 }

--- a/clearpath_motor_drivers/lynx_motor_driver/src/lynx_motor_node.cpp
+++ b/clearpath_motor_drivers/lynx_motor_driver/src/lynx_motor_node.cpp
@@ -32,7 +32,8 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
 LynxMotorNode::LynxMotorNode(const std::string node_name) :
  Node(node_name),
  updating_(false),
- debugging_(false)
+ debugging_(false),
+ updater_(this)
 {
   // Declare parameters
   this->declare_parameter("can_bus", "can0");
@@ -94,15 +95,24 @@ LynxMotorNode::LynxMotorNode(const std::string node_name) :
       node_handle_,
       std::bind(&LynxMotorNode::canRxCallback, this, std::placeholders::_1)));
 
+  // Setup diagnostics
+  updater_.setHardwareID("Lynx");
+  updater_.add("Lynx Motor Driver Summary", this, &LynxMotorNode::protectionDiagnostic);
+  firmware_version_expected_ = parseFirmwareVersion(getDefaultFirmware());
+
   // Initialise drivers
   for (uint8_t i = 0; i < joint_names_.size(); i++)
   {
-    drivers_.push_back(lynx_motor_driver::LynxMotorDriver(
+    drivers_.emplace_back(
       joint_can_ids_[i],
       joint_names_[i],
       joint_directions_[i],
       can_interface_
-    ));
+    );
+
+    // Add diagnostic tasks
+    std::string name = "Lynx Motor Driver " + std::to_string(i + 1) + " (" + joint_names_[i] + ")";
+    updater_.add(name, std::bind(&LynxMotorNode::driverDiagnostic, this, std::placeholders::_1, i));
   }
 
   // Subsciber
@@ -367,4 +377,143 @@ void LynxMotorNode::startDebug()
     rclcpp::SensorDataQoS());
 
   debugging_ = true;
+}
+
+/**
+ * @brief Diagnostic task to report details for each motor driver
+ *
+ * @param i Driver index number
+ */
+void LynxMotorNode::driverDiagnostic(DiagnosticStatusWrapper & stat, int i)
+{
+  //Fimware update process
+  if (updating_) {
+    // ignore everything else if actively updating the firmware, messages are not valid
+    stat.summary(DiagnosticStatusWrapper::WARN, "Firmware Updating");
+    return;
+  }
+
+  drivers_[i].runFreqStatus(stat);
+
+  if (stat.level == DiagnosticStatusWrapper::ERROR) {
+    // Error from the frequency status means that no messages are being received
+    // therefore return instead of reporting on old data
+    return;
+  }
+
+  stat.add("CAN ID", (int)status_msg_.drivers[i].can_id);
+  stat.add("Joint Name", status_msg_.drivers[i].joint_name);
+  stat.add("Firmware Version", status_msg_.drivers[i].firmware_version);
+  stat.add("Motor Temperature (C)", status_msg_.drivers[i].motor_temperature);
+  stat.add("BLDC MCU Temperature (C)", status_msg_.drivers[i].mcu_temperature);
+  stat.add("BLDC PCB Temperature (C)", status_msg_.drivers[i].pcb_temperature);
+  stat.add("Hardware Triggered Stop", (status_msg_.drivers[i].stopped ? "True" : "False"));
+
+  try {
+    // Set message to warn if motor is in overheated or throttled states
+    if ((system_protection_msg_.motor_states[i] == LynxSystemProtection::THROTTLED) ||
+        (system_protection_msg_.motor_states[i] == LynxSystemProtection::OVERHEATED)) {
+      stat.mergeSummary(DiagnosticStatusWrapper::WARN,
+                        LYNX_PROTECTION_LABELS_.at(system_protection_msg_.motor_states[i]));
+    }
+  } catch(const std::out_of_range & e) {
+    RCLCPP_ERROR(this->get_logger(),
+      "Unknown Lynx system protection message motor state value with no string description: %s",
+      e.what());
+  }
+
+  // Status flags
+  for (auto label : STATUS_FLAG_LABELS_) {
+    // isolate and save the bit associated with the flag
+    bool flag = (status_msg_.drivers[i].status_flags >> label.first) & 0x1;
+    stat.add(label.second, flag ? "True" : "False");
+    if (flag) {
+      if (label.first == LynxStatus::STATUS_FLAG_CALIBRATION_REQUESTED) {
+        // Okay state message only gets added if all previous messages were okay
+        stat.mergeSummary(DiagnosticStatusWrapper::OK, label.second);
+      }
+      else if (label.first == LynxStatus::STATUS_FLAG_ESTOPPED){
+        stat.mergeSummary(DiagnosticStatusWrapper::WARN, label.second);
+      }
+    }
+  }
+
+  // Error flags
+  for (auto label : ERROR_FLAG_LABELS_) {
+    bool flag = (status_msg_.drivers[i].error_flags >> label.first) & 0x1;
+    stat.add(label.second, flag ? "True" : "False");
+    if (flag) {
+      // Flag any active errors in the summary and set level to error
+      stat.mergeSummary(DiagnosticStatusWrapper::ERROR, label.second);
+    }
+  }
+
+  std::string firmware_current = status_msg_.drivers[i].firmware_version;
+  size_t pos = status_msg_.drivers[i].firmware_version.find(' ');
+  if (pos != std::string::npos) {
+    firmware_current = status_msg_.drivers[i].firmware_version.substr(0, pos);
+  }
+
+  // Firmware check
+  if (firmware_version_expected_ != firmware_current) {
+    stat.mergeSummaryf(DiagnosticStatusWrapper::ERROR,
+                       "Firmware mismatch (\"%s\" is installed but expected \"%s\")",
+                       firmware_current.c_str(),
+                       firmware_version_expected_.c_str());
+  }
+}
+
+/**
+ * @brief Diagnostic task to report overal system protection status for all drivers
+ *
+ */
+void LynxMotorNode::protectionDiagnostic(DiagnosticStatusWrapper & stat)
+{
+  // Fimware update process
+  if (updating_) {
+    // Ignore everything else if actively updating the firmware, messages are not valid
+    stat.summary(DiagnosticStatusWrapper::WARN, "Firmware Updating");
+    return;
+  }
+
+  try {
+    // Interpret system protection message
+    if (system_protection_msg_.system_state == LynxSystemProtection::NORMAL) {
+      stat.summary(DiagnosticStatusWrapper::OK,
+                  LYNX_PROTECTION_LABELS_.at(system_protection_msg_.system_state));
+    } else if (system_protection_msg_.system_state == LynxSystemProtection::ERROR) {
+      stat.summary(DiagnosticStatusWrapper::ERROR,
+                  LYNX_PROTECTION_LABELS_.at(system_protection_msg_.system_state));
+    } else {
+      stat.summary(DiagnosticStatusWrapper::WARN,
+                  LYNX_PROTECTION_LABELS_.at(system_protection_msg_.system_state));
+    }
+  } catch(const std::out_of_range & e) {
+    RCLCPP_ERROR(this->get_logger(),
+      "Unknown Lynx system protection message system state value with no string description: %s",
+      e.what());
+  }
+
+  try {
+    for (unsigned i = 0; i < system_protection_msg_.motor_states.size(); i++) {
+      stat.add(LYNX_MOTOR_LABELS_.at(i) + " Motor State",
+              LYNX_PROTECTION_LABELS_.at(system_protection_msg_.motor_states[i]));
+    }
+  } catch(const std::out_of_range & e) {
+    RCLCPP_ERROR(this->get_logger(),
+      "Unknown Lynx system protection message motor state value with no string description: %s",
+      e.what());
+  }
+}
+
+std::string LynxMotorNode::parseFirmwareVersion(std::string filename)
+{
+  std::regex rgx("([Ll]ynx[_-][Ff]irmware[_-][Rr]elease[_-])([0-9]+[.][0-9]+[.][0-9]+)");
+  std::smatch match;
+  std::string version = "unknown";
+
+  if (std::regex_search(filename, match, rgx)) {
+    version = match[2]; // Capture the 2nd subgroup which contains the version number string
+  }
+  return version;
 }

--- a/clearpath_motor_drivers/lynx_motor_driver/src/update_action.cpp
+++ b/clearpath_motor_drivers/lynx_motor_driver/src/update_action.cpp
@@ -37,9 +37,9 @@ static constexpr uint8_t ALIVE_CHECK_ATTEMPTS = 100;
 
 /**
  * @brief Read
- * 
- * @param filename 
- * @return std::queue<uint8_t> 
+ *
+ * @param filename
+ * @return std::queue<uint8_t>
  */
 std::queue<uint8_t> LynxMotorNode::readBinaryFile(const std::string filename)
 {
@@ -77,10 +77,10 @@ std::queue<uint8_t> LynxMotorNode::readBinaryFile(const std::string filename)
 
 /**
  * @brief Handle Update goal request
- * 
+ *
  * @param uuid UUID
  * @param goal Goal pointer
- * @return rclcpp_action::GoalResponse 
+ * @return rclcpp_action::GoalResponse
  */
 rclcpp_action::GoalResponse LynxMotorNode::handleUpdateGoal(
   const rclcpp_action::GoalUUID & uuid,
@@ -129,7 +129,7 @@ rclcpp_action::GoalResponse LynxMotorNode::handleUpdateGoal(
       return rclcpp_action::GoalResponse::REJECT;
     }
   }
-  
+
   app = readBinaryFile(filename);
   RCLCPP_INFO(this->get_logger(), "Uploading file %s len %ld", filename.c_str(), app.size());
   // Copy binary to each driver
@@ -143,9 +143,9 @@ rclcpp_action::GoalResponse LynxMotorNode::handleUpdateGoal(
 
 /**
  * @brief Handle update goal cancelled
- * 
+ *
  * @param goal_handle Pointer to goal handle
- * @return rclcpp_action::CancelResponse 
+ * @return rclcpp_action::CancelResponse
  */
 rclcpp_action::CancelResponse LynxMotorNode::handleUpdateCancel(
   const std::shared_ptr<GoalHandleUpdate> goal_handle)
@@ -161,7 +161,7 @@ rclcpp_action::CancelResponse LynxMotorNode::handleUpdateCancel(
 
 /**
  * @brief Handle update goal being accepted
- * 
+ *
  * @param goal_handle Pointer to goal handle
  */
 void LynxMotorNode::handleUpdateAccepted(const std::shared_ptr<GoalHandleUpdate> goal_handle)
@@ -175,7 +175,7 @@ void LynxMotorNode::handleUpdateAccepted(const std::shared_ptr<GoalHandleUpdate>
 
 /**
  * @brief Execute update action
- * 
+ *
  * @param goal_handle Pointer to goal handle
  */
 void LynxMotorNode::executeUpdateAction(const std::shared_ptr<GoalHandleUpdate> goal_handle)
@@ -263,7 +263,7 @@ void LynxMotorNode::executeUpdateAction(const std::shared_ptr<GoalHandleUpdate> 
 
     // Send 100% on last feedback message
     feedback->progress.at(i) = 100.0;
-    goal_handle->publish_feedback(feedback);    
+    goal_handle->publish_feedback(feedback);
 
     i++;
   }

--- a/clearpath_motor_drivers/lynx_motor_driver/src/update_action.cpp
+++ b/clearpath_motor_drivers/lynx_motor_driver/src/update_action.cpp
@@ -30,6 +30,8 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
 #include <queue>
 #include <glob.h>
 
+#define UNKNOWN "unknown"
+
 // Binary files will have 15 reserved bytes that should be ignored
 static constexpr uint8_t BINARY_FILE_RESERVED_BYTE_START_INDEX = 3;
 static constexpr uint8_t BINARY_FILE_RESERVED_BYTE_END_INDEX = 18;
@@ -106,26 +108,8 @@ rclcpp_action::GoalResponse LynxMotorNode::handleUpdateGoal(
   }
   else // Use default binary
   {
-    // Find default binary in lynx_motor_driver package
-    std::filesystem::path dir(ament_index_cpp::get_package_share_directory("lynx_motor_driver"));
-    std::filesystem::path folder("bin");
-    std::filesystem::path file("lynx_firmware-release-*.txt");
-    filename = dir / folder / file;
-
-    // Find file name from wildcard
-    glob_t globResult;
-    int globStatus = glob(filename.c_str(), 0, nullptr, &globResult);
-
-    if (globStatus == 0)
-    {
-      // Use first file
-      filename = std::string(globResult.gl_pathv[0]);
-      globfree(&globResult);
-    }
-    else
-    {
-      // Can't find default binary
-      RCLCPP_ERROR(this->get_logger(), "Default binary file not found");
+    filename = getDefaultFirmware();
+    if (filename == UNKNOWN) {
       return rclcpp_action::GoalResponse::REJECT;
     }
   }
@@ -139,6 +123,37 @@ rclcpp_action::GoalResponse LynxMotorNode::handleUpdateGoal(
   }
 
   return rclcpp_action::GoalResponse::ACCEPT_AND_EXECUTE;
+}
+
+/**
+ * @brief Get the filename of the default firmware binary
+ *
+ * @return std::String
+ */
+std::string LynxMotorNode::getDefaultFirmware() {
+  // Find default binary in lynx_motor_driver package
+  std::filesystem::path dir(ament_index_cpp::get_package_share_directory("lynx_motor_driver"));
+  std::filesystem::path folder("bin");
+  std::filesystem::path file("lynx_firmware-release-*.txt");
+  std::string filename = dir / folder / file;
+
+  // Find file name from wildcard
+  glob_t globResult;
+  int globStatus = glob(filename.c_str(), 0, nullptr, &globResult);
+
+  if (globStatus == 0)
+  {
+    // Use first file
+    filename = std::string(globResult.gl_pathv[0]);
+    globfree(&globResult);
+  }
+  else
+  {
+    // Can't find default binary
+    RCLCPP_ERROR(this->get_logger(), "Default binary file not found");
+    filename = UNKNOWN;
+  }
+  return filename;
 }
 
 /**


### PR DESCRIPTION
Added Lynx motor driver diagnostics
- reports all information from the Lynx messages into diagnostics
- monitors the rate of the feedback message over can from each driver board
- compares firmware version between the default firmware binary and the installed firmware on each driver board

This update does not include reporting on the firmware update process to indicate update failures and/or the need to reboot after the firmware update. Both of those are future work.