### PR TITLE
Move extras launch into a new service

### DIFF
--- a/clearpath_generator_robot/clearpath_generator_robot/launch/generator.py
+++ b/clearpath_generator_robot/clearpath_generator_robot/launch/generator.py
@@ -424,16 +424,6 @@ class RobotLaunchGenerator(LaunchGenerator):
                 # Include sensor launch in top level sensors launch file
                 sensors_service_launch_writer.add(sensor_launch.launch_file)
 
-        if self.clearpath_config.platform.extras.launch:
-            extra_launch = LaunchFile(
-                name=(os.path.basename(
-                    self.clearpath_config.platform.extras.launch['path']
-                )).split('.')[0],
-                path=os.path.dirname(self.clearpath_config.platform.extras.launch['path']),
-                package=Package(self.clearpath_config.platform.extras.launch['package']),
-            )
-            sensors_service_launch_writer.add(extra_launch)
-
         sensors_service_launch_writer.generate_file()
 
     def generate_platform(self) -> None:
@@ -450,6 +440,22 @@ class RobotLaunchGenerator(LaunchGenerator):
             platform_service_launch_writer.add(self.bms_node)
 
         platform_service_launch_writer.generate_file()
+
+        platform_extras_service_launch_writer = LaunchWriter(
+            self.platform_extras_service_launch_file)
+        platform_extras_service_launch_writer.add(self.platform_extras_launch_file)
+
+        if self.clearpath_config.platform.extras.launch:
+            extra_launch = LaunchFile(
+                name=(os.path.basename(
+                    self.clearpath_config.platform.extras.launch['path']
+                )).split('.')[0],
+                path=os.path.dirname(self.clearpath_config.platform.extras.launch['path']),
+                package=Package(self.clearpath_config.platform.extras.launch['package']),
+            )
+            platform_extras_service_launch_writer.add(extra_launch)
+
+        platform_extras_service_launch_writer.generate_file()
 
     def generate_manipulators(self) -> None:
         manipulator_service_launch_writer = LaunchWriter(self.manipulators_service_launch_file)

--- a/clearpath_robot/scripts/install
+++ b/clearpath_robot/scripts/install
@@ -99,6 +99,33 @@ class PlatformProvider(robot_upstart.providers.Generic):
         }
 
 
+class PlatformExtrasProvider(robot_upstart.providers.Generic):
+    def post_install(self):
+        pass
+
+    def generate_install(self):
+        platform_extras_service_path = os.path.join(
+            get_package_share_directory('clearpath_robot'),
+            'services/clearpath-platform-extras.service')
+        with open(platform_extras_service_path) as f:
+            platform_extras_service_contents: str = ''
+            platform_extras_service_lines = f.readlines()
+            for line in platform_extras_service_lines:
+                # Replace User with username from config
+                if 'User=' in line:
+                    line = 'User={0}\n'.format(clearpath_config.system.username)
+                platform_extras_service_contents += line
+        return {
+            '/lib/systemd/system/clearpath-platform-extras.service': {
+                'content': platform_extras_service_contents,
+                'mode': 0o644
+            },
+            '/etc/systemd/system/clearpath-robot.service.wants/clearpath-platform-extras.service': {  # noqa: E501
+                'symlink': '/lib/systemd/system/clearpath-platform-extras.service'
+            }
+        }
+
+
 class SensorsProvider(robot_upstart.providers.Generic):
     def post_install(self):
         pass
@@ -286,6 +313,9 @@ config_path = os.path.join(setup_path, 'robot.yaml')
 platform_service_launch = os.path.join(
     setup_path,
     'platform/launch/platform-service.launch.py')
+platform_extras_service_launch = os.path.join(
+    setup_path,
+    'platform-extras/launch/platform-extras-service.launch.py')
 sensors_service_launch = os.path.join(
     setup_path,
     'sensors/launch/sensors-service.launch.py')
@@ -314,6 +344,9 @@ except:
 if not os.path.isfile(platform_service_launch):
     os.makedirs(os.path.dirname(platform_service_launch), exist_ok=True)
     open(platform_service_launch, 'w+').close()
+if not os.path.isfile(platform_extras_service_launch):
+    os.makedirs(os.path.dirname(platform_extras_service_launch), exist_ok=True)
+    open(platform_extras_service_launch, 'w+').close()
 if not os.path.isfile(sensors_service_launch):
     os.makedirs(os.path.dirname(sensors_service_launch), exist_ok=True)
     open(sensors_service_launch, 'w+').close()
@@ -330,10 +363,16 @@ platform = robot_upstart.Job(
 
 platform.symlink = True
 platform.add(filename=platform_service_launch)
-platform.install()
+platform.install(Provider=PlatformProvider)
 
-platform_extras = robot_upstart.Job(workspace_setup=workspace_setup)
-platform_extras.install(Provider=PlatformProvider)
+platform_extras = robot_upstart.Job(
+    name='clearpath-platform-extras',
+    rmw=rmw,
+    workspace_setup=workspace_setup,
+    ros_domain_id=domain_id)
+platform_extras.symlink = True
+platform_extras.add(filename=platform_extras_service_launch)
+platform_extras.install(Provider=PlatformExtrasProvider)
 
 # Sensors
 sensors = robot_upstart.Job(

--- a/clearpath_robot/scripts/install
+++ b/clearpath_robot/scripts/install
@@ -374,6 +374,7 @@ platform_extras = robot_upstart.Job(
     rmw=rmw,
     workspace_setup=workspace_setup,
     ros_domain_id=domain_id)
+
 platform_extras.symlink = True
 platform_extras.add(filename=platform_extras_service_launch)
 platform_extras.install()

--- a/clearpath_robot/scripts/install
+++ b/clearpath_robot/scripts/install
@@ -42,6 +42,28 @@ import os
 import robot_upstart.providers
 
 
+def replace_user_in_systemd_job(
+    username: str,
+    service_path: str,
+) -> str:
+    """
+    Read a systemd job file, replace the username for jobs, and return the contents.
+
+    :param username: The desired username to use as the owner of the job
+    :param service_path: The path to the file to process
+    :return: The same contents as the provided file, but with the username replaced to
+        be the provided one
+    """
+    file_contents: str = ''
+    with open(service_path, 'r') as f:
+        for line in f.readlines():
+            # Replace User with username from config
+            if 'User=' in line:
+                line = f'User={username}\n'
+            file_contents += line
+    return file_contents
+
+
 class VirtualCANProvider(robot_upstart.providers.Generic):
     def post_install(self):
         pass
@@ -80,14 +102,10 @@ class PlatformProvider(robot_upstart.providers.Generic):
         platform_service_path = os.path.join(
             get_package_share_directory('clearpath_robot'),
             'services/clearpath-platform.service')
-        with open(platform_service_path) as f:
-            platform_service_contents: str = ''
-            platform_service_lines = f.readlines()
-            for line in platform_service_lines:
-                # Replace User with username from config
-                if 'User=' in line:
-                    line = 'User={0}\n'.format(clearpath_config.system.username)
-                platform_service_contents += line
+        platform_service_contents = replace_user_in_systemd_job(
+            clearpath_config.system.username,
+            platform_service_path,
+        )
         return {
             '/lib/systemd/system/clearpath-platform.service': {
                 'content': platform_service_contents,
@@ -107,14 +125,10 @@ class PlatformExtrasProvider(robot_upstart.providers.Generic):
         platform_extras_service_path = os.path.join(
             get_package_share_directory('clearpath_robot'),
             'services/clearpath-platform-extras.service')
-        with open(platform_extras_service_path) as f:
-            platform_extras_service_contents: str = ''
-            platform_extras_service_lines = f.readlines()
-            for line in platform_extras_service_lines:
-                # Replace User with username from config
-                if 'User=' in line:
-                    line = 'User={0}\n'.format(clearpath_config.system.username)
-                platform_extras_service_contents += line
+        platform_extras_service_contents = replace_user_in_systemd_job(
+            clearpath_config.system.username,
+            platform_extras_service_path,
+        )
         return {
             '/lib/systemd/system/clearpath-platform-extras.service': {
                 'content': platform_extras_service_contents,
@@ -134,14 +148,10 @@ class SensorsProvider(robot_upstart.providers.Generic):
         sensors_service_path = os.path.join(
             get_package_share_directory('clearpath_robot'),
             'services/clearpath-sensors.service')
-        with open(sensors_service_path) as f:
-            sensors_service_contents: str = ''
-            sensors_service_lines = f.readlines()
-            for line in sensors_service_lines:
-                # Replace User with username from config
-                if 'User=' in line:
-                    line = 'User={0}\n'.format(clearpath_config.system.username)
-                sensors_service_contents += line
+        sensors_service_contents = replace_user_in_systemd_job(
+            clearpath_config.system.username,
+            sensors_service_path,
+        )
         return {
             '/lib/systemd/system/clearpath-sensors.service': {
                 'content': sensors_service_contents,
@@ -161,14 +171,10 @@ class ManipulatorsProvider(robot_upstart.providers.Generic):
         manipulators_service_path = os.path.join(
             get_package_share_directory('clearpath_robot'),
             'services/clearpath-manipulators.service')
-        with open(manipulators_service_path) as f:
-            manipulators_service_contents: str = ''
-            manipulators_service_lines = f.readlines()
-            for line in manipulators_service_lines:
-                # Replace User with username from config
-                if 'User=' in line:
-                    line = 'User={0}\n'.format(clearpath_config.system.username)
-                manipulators_service_contents += line
+        manipulators_service_contents = replace_user_in_systemd_job(
+            clearpath_config.system.username,
+            manipulators_service_path,
+        )
         return {
             '/lib/systemd/system/clearpath-manipulators.service': {
                 'content': manipulators_service_contents,
@@ -188,15 +194,10 @@ class DiscoveryServerProvider(robot_upstart.providers.Generic):
         discovery_service_path = os.path.join(
             get_package_share_directory('clearpath_robot'),
             'services/clearpath-discovery.service')
-        with open(discovery_service_path) as f:
-            discovery_service_contents: str = ''
-            discovery_service_lines = f.readlines()
-            for line in discovery_service_lines:
-                # Replace User with username from config
-                if 'User=' in line:
-                    line = 'User={0}\n'.format(clearpath_config.system.username)
-                discovery_service_contents += line
-
+        discovery_service_contents = replace_user_in_systemd_job(
+            clearpath_config.system.username,
+            discovery_service_path,
+        )
         return {
             '/lib/systemd/system/clearpath-discovery.service': {
                 'content': discovery_service_contents,
@@ -216,15 +217,10 @@ class ZenohRouterServiceProvider(robot_upstart.providers.Generic):
         zenoh_router_service_path = os.path.join(
             get_package_share_directory('clearpath_robot'),
             'services/clearpath-zenoh-router.service')
-        with open(zenoh_router_service_path) as f:
-            zenoh_router_service_contents: str = ''
-            zenoh_router_lines = f.readlines()
-            for line in zenoh_router_lines:
-                # Replace User with username from config
-                if 'User=' in line:
-                    line = f'User={clearpath_config.system.username}\n'
-                zenoh_router_service_contents += line
-
+        zenoh_router_service_contents = replace_user_in_systemd_job(
+            clearpath_config.system.username,
+            zenoh_router_service_path,
+        )
         return {
                 '/lib/systemd/system/clearpath-zenoh-router.service': {
                     'content': zenoh_router_service_contents,
@@ -251,14 +247,10 @@ class RobotProvider(robot_upstart.providers.Generic):
             get_package_share_directory('clearpath_robot'),
             'scripts/check')
 
-        with open(robot_service_path) as f:
-            robot_service_contents: str = ''
-            robot_service_lines = f.readlines()
-            for line in robot_service_lines:
-                # Replace User with username from config
-                if 'User=' in line:
-                    line = 'User={0}\n'.format(clearpath_config.system.username)
-                robot_service_contents += line
+        robot_service_contents = replace_user_in_systemd_job(
+            clearpath_config.system.username,
+            robot_service_path
+        )
         with open(robot_service_execpre_contents_path) as f:
             robot_service_execpre_contents = f.read()
         with open(robot_service_exec_contents_path) as f:

--- a/clearpath_robot/scripts/install
+++ b/clearpath_robot/scripts/install
@@ -333,7 +333,7 @@ domain_id = clearpath_config.system.domain_id
 # Check that user exists
 try:
     pwd.getpwnam(clearpath_config.system.username)
-except:
+except:  # noqa: E722
     print(
         f'Error. User "{clearpath_config.system.username}" does not exist.\n'
         f'Modify the "robot.yaml" system.username entry to match an existing user.'

--- a/clearpath_robot/scripts/install
+++ b/clearpath_robot/scripts/install
@@ -363,8 +363,12 @@ platform = robot_upstart.Job(
 
 platform.symlink = True
 platform.add(filename=platform_service_launch)
-platform.install(Provider=PlatformProvider)
+platform.install()
 
+platform_provider_files = robot_upstart.Job(workspace_setup=workspace_setup)
+platform_provider_files.install(Provider=PlatformProvider)
+
+# Platform extras
 platform_extras = robot_upstart.Job(
     name='clearpath-platform-extras',
     rmw=rmw,
@@ -372,7 +376,10 @@ platform_extras = robot_upstart.Job(
     ros_domain_id=domain_id)
 platform_extras.symlink = True
 platform_extras.add(filename=platform_extras_service_launch)
-platform_extras.install(Provider=PlatformExtrasProvider)
+platform_extras.install()
+
+platform_extras_provider_files = robot_upstart.Job(workspace_setup=workspace_setup)
+platform_extras_provider_files.install(Provider=PlatformExtrasProvider)
 
 # Sensors
 sensors = robot_upstart.Job(
@@ -385,8 +392,8 @@ sensors.symlink = True
 sensors.add(filename=sensors_service_launch)
 sensors.install()
 
-sensors_extras = robot_upstart.Job(workspace_setup=workspace_setup)
-sensors_extras.install(Provider=SensorsProvider)
+sensors_provider_files = robot_upstart.Job(workspace_setup=workspace_setup)
+sensors_provider_files.install(Provider=SensorsProvider)
 
 # Manipulators
 manipulators = robot_upstart.Job(
@@ -399,8 +406,8 @@ manipulators.symlink = True
 manipulators.add(filename=manipulators_service_launch)
 manipulators.install()
 
-manipulators_extras = robot_upstart.Job(workspace_setup=workspace_setup)
-manipulators_extras.install(Provider=ManipulatorsProvider)
+manipulators_provider_files = robot_upstart.Job(workspace_setup=workspace_setup)
+manipulators_provider_files.install(Provider=ManipulatorsProvider)
 
 # Discovery Server
 discovery_server = robot_upstart.Job(workspace_setup=workspace_setup)

--- a/clearpath_robot/services/clearpath-platform-extras.service
+++ b/clearpath_robot/services/clearpath-platform-extras.service
@@ -1,0 +1,12 @@
+[Unit]
+Description="Clearpath robot sub-service, launch all user-defined extra platform nodes"
+PartOf=clearpath-robot.service
+After=clearpath-robot.service
+
+[Service]
+User=administrator
+Type=simple
+ExecStart=/usr/sbin/clearpath-platform-extras-start
+
+[Install]
+WantedBy=clearpath-robot.service


### PR DESCRIPTION
Create a new platform-extras.service to contain the platform.extras.launch instead of including that launch as part of the sensors service

Multiple part change
- https://github.com/clearpathrobotics/clearpath_robot/pull/178
- https://github.com/clearpathrobotics/clearpath_common/pull/185