### PR TITLE
Move symlinks into `clearpath-robot.service.wants` instead of `multi-user.target.wants`

### DIFF
--- a/clearpath_robot/scripts/install
+++ b/clearpath_robot/scripts/install
@@ -71,10 +71,12 @@ class ClearpathRobotProvider(robot_upstart.providers.Systemd):
         files = super().generate_install()
 
         # replace the multi-user.target.wants items with clearpath-robot.target.wants
-        clearpath_robot_wants = files['/etc/systemd/system/multi-user.target.wants']
-        files['/etc/systemd/system/clearpath-robot.target.wants'] = clearpath_robot_wants
-        files.pop('/etc/systemd/system/multi-user.target.wants')
-
+        multi_user_path = os.path.join(
+            self.root, "etc/systemd/system/multi-user.target.wants", self.job.name + ".service")
+        clearpath_robot_path = os.path.join(
+            self.root, "etc/systemd/system/clearpath-robot.target.wants", self.job.name + ".service")
+        files[clearpath_robot_path] = files[multi_user_path]
+        files.pop(multi_user_path)
         return files
 
 

--- a/clearpath_robot/scripts/install
+++ b/clearpath_robot/scripts/install
@@ -64,6 +64,20 @@ def replace_user_in_systemd_job(
     return file_contents
 
 
+class ClearpathRobotProvider(robot_upstart.providers.Systemd):
+    """Same a the standard systemd provider, but with symlinks in clearpath_robot.wants."""
+
+    def generate_install(self):
+        files = super().generate_install()
+
+        # replace the multi-user.target.wants items with clearpath-robot.target.wants
+        clearpath_robot_wants = files['/etc/systemd/system/multi-user.target.wants']
+        files['/etc/systemd/system/clearpath-robot.target.wants'] = clearpath_robot_wants
+        files.pop('/etc/systemd/system/multi-user.target.wants')
+
+        return files
+
+
 class VirtualCANProvider(robot_upstart.providers.Generic):
     def post_install(self):
         pass
@@ -267,7 +281,10 @@ class RobotProvider(robot_upstart.providers.Generic):
             '/usr/sbin/clearpath-robot-check': {
                 'content': robot_service_exec_contents,
                 'mode': 0o755
-            }
+            },
+            '/etc/systemd/system/multi-user.target.wants': {
+                'symlink': '/lib/systemd/system/clearpath-robot.service'
+            },
         }
 
 class ShutdownProvider(robot_upstart.providers.Generic):
@@ -346,6 +363,11 @@ if not os.path.isfile(manipulators_service_launch):
     os.makedirs(os.path.dirname(manipulators_service_launch), exist_ok=True)
     open(manipulators_service_launch, 'w+').close()
 
+# Robot
+# this should be first, as subsequent jobs are part of this service
+robot = robot_upstart.Job(workspace_setup=workspace_setup)
+robot.install(Provider=RobotProvider)
+
 # Platform
 platform = robot_upstart.Job(
     name='clearpath-platform',
@@ -355,7 +377,7 @@ platform = robot_upstart.Job(
 
 platform.symlink = True
 platform.add(filename=platform_service_launch)
-platform.install()
+platform.install(provider=ClearpathRobotProvider)
 
 platform_provider_files = robot_upstart.Job(workspace_setup=workspace_setup)
 platform_provider_files.install(Provider=PlatformProvider)
@@ -369,7 +391,7 @@ platform_extras = robot_upstart.Job(
 
 platform_extras.symlink = True
 platform_extras.add(filename=platform_extras_service_launch)
-platform_extras.install()
+platform_extras.install(provider=ClearpathRobotProvider)
 
 platform_extras_provider_files = robot_upstart.Job(workspace_setup=workspace_setup)
 platform_extras_provider_files.install(Provider=PlatformExtrasProvider)
@@ -383,7 +405,7 @@ sensors = robot_upstart.Job(
 
 sensors.symlink = True
 sensors.add(filename=sensors_service_launch)
-sensors.install()
+sensors.install(provider=ClearpathRobotProvider)
 
 sensors_provider_files = robot_upstart.Job(workspace_setup=workspace_setup)
 sensors_provider_files.install(Provider=SensorsProvider)
@@ -397,7 +419,7 @@ manipulators = robot_upstart.Job(
 
 manipulators.symlink = True
 manipulators.add(filename=manipulators_service_launch)
-manipulators.install()
+manipulators.install(provider=ClearpathRobotProvider)
 
 manipulators_provider_files = robot_upstart.Job(workspace_setup=workspace_setup)
 manipulators_provider_files.install(Provider=ManipulatorsProvider)
@@ -418,8 +440,5 @@ vcan_bridge.install(Provider=VirtualCANProvider)
 shutdown = robot_upstart.Job(workspace_setup=workspace_setup)
 shutdown.install(Provider=ShutdownProvider)
 
-# Robot
-robot = robot_upstart.Job(workspace_setup=workspace_setup)
-robot.install(Provider=RobotProvider)
 print('** To complete installation please run the following command:')
 print('  sudo systemctl daemon-reload && sudo systemctl start clearpath-robot')

--- a/clearpath_robot/scripts/install
+++ b/clearpath_robot/scripts/install
@@ -377,7 +377,7 @@ platform = robot_upstart.Job(
 
 platform.symlink = True
 platform.add(filename=platform_service_launch)
-platform.install(provider=ClearpathRobotProvider)
+platform.install(Provider=ClearpathRobotProvider)
 
 platform_provider_files = robot_upstart.Job(workspace_setup=workspace_setup)
 platform_provider_files.install(Provider=PlatformProvider)
@@ -391,7 +391,7 @@ platform_extras = robot_upstart.Job(
 
 platform_extras.symlink = True
 platform_extras.add(filename=platform_extras_service_launch)
-platform_extras.install(provider=ClearpathRobotProvider)
+platform_extras.install(Provider=ClearpathRobotProvider)
 
 platform_extras_provider_files = robot_upstart.Job(workspace_setup=workspace_setup)
 platform_extras_provider_files.install(Provider=PlatformExtrasProvider)
@@ -405,7 +405,7 @@ sensors = robot_upstart.Job(
 
 sensors.symlink = True
 sensors.add(filename=sensors_service_launch)
-sensors.install(provider=ClearpathRobotProvider)
+sensors.install(Provider=ClearpathRobotProvider)
 
 sensors_provider_files = robot_upstart.Job(workspace_setup=workspace_setup)
 sensors_provider_files.install(Provider=SensorsProvider)
@@ -419,7 +419,7 @@ manipulators = robot_upstart.Job(
 
 manipulators.symlink = True
 manipulators.add(filename=manipulators_service_launch)
-manipulators.install(provider=ClearpathRobotProvider)
+manipulators.install(Provider=ClearpathRobotProvider)
 
 manipulators_provider_files = robot_upstart.Job(workspace_setup=workspace_setup)
 manipulators_provider_files.install(Provider=ManipulatorsProvider)

--- a/clearpath_robot/scripts/install
+++ b/clearpath_robot/scripts/install
@@ -442,5 +442,14 @@ vcan_bridge.install(Provider=VirtualCANProvider)
 shutdown = robot_upstart.Job(workspace_setup=workspace_setup)
 shutdown.install(Provider=ShutdownProvider)
 
-print('** To complete installation please run the following command:')
-print('  sudo systemctl daemon-reload && sudo systemctl start clearpath-robot')
+print("""
+
+** INSTALLATION COMPLETE **
+
+To finalize installation please run the following command:
+
+    sudo systemctl enable clearpath-robot.service && \\
+    sudo systemctl daemon-reload && \\
+    sudo systemctl start clearpath-robot
+
+""")

--- a/clearpath_robot/scripts/install
+++ b/clearpath_robot/scripts/install
@@ -70,11 +70,11 @@ class ClearpathRobotProvider(robot_upstart.providers.Systemd):
     def generate_install(self):
         files = super().generate_install()
 
-        # replace the multi-user.target.wants items with clearpath-robot.target.wants
+        # replace the multi-user.target.wants items with clearpath-robot.service.wants
         multi_user_path = os.path.join(
             self.root, "etc/systemd/system/multi-user.target.wants", self.job.name + ".service")
         clearpath_robot_path = os.path.join(
-            self.root, "etc/systemd/system/clearpath-robot.target.wants", self.job.name + ".service")
+            self.root, "etc/systemd/system/clearpath-robot.service.wants", self.job.name + ".service")
         files[clearpath_robot_path] = files[multi_user_path]
         files.pop(multi_user_path)
         return files

--- a/clearpath_robot/scripts/install
+++ b/clearpath_robot/scripts/install
@@ -284,7 +284,7 @@ class RobotProvider(robot_upstart.providers.Generic):
                 'content': robot_service_exec_contents,
                 'mode': 0o755
             },
-            '/etc/systemd/system/multi-user.target.wants': {
+            '/etc/systemd/system/multi-user.target.wants/clearpath-robot.service': {
                 'symlink': '/lib/systemd/system/clearpath-robot.service'
             },
         }
@@ -448,8 +448,6 @@ print("""
 
 To finalize installation please run the following command:
 
-    sudo systemctl enable clearpath-robot.service && \\
-    sudo systemctl daemon-reload && \\
-    sudo systemctl start clearpath-robot
+    sudo systemctl daemon-reload && sudo systemctl start clearpath-robot
 
 """)


### PR DESCRIPTION
Create a new `systemd` provider that doesn't explicitly add symlinks to `multi-user.target.wants`, use this provider to create the sub-jobs that are part of the `clearpath-robot.service` job.

Fix the symlink generated by `RobotProvider` so it properly creates the main job symlink in `multi-user.target.wants`.

Resolves RPSW-2228