### PR TITLE
Add additional allowed warnings/errors for specific platforms

### DIFF
--- a/clearpath_tests/clearpath_tests/diagnostic_test.py
+++ b/clearpath_tests/clearpath_tests/diagnostic_test.py
@@ -80,7 +80,7 @@ allowed_errors_by_platform = {
 
     },
     Platform.GENERIC: {
-
+        # no generic-specific exceptions
     },
     Platform.J100: {
         'clearpath_diagnostic_updater: Battery Management System': [
@@ -99,7 +99,7 @@ allowed_errors_by_platform = {
         ],
     },
     Platform.W200: {
-
+        # not yet supported
     },
 }
 

--- a/clearpath_tests/clearpath_tests/diagnostic_test.py
+++ b/clearpath_tests/clearpath_tests/diagnostic_test.py
@@ -68,16 +68,36 @@ allowed_errors_by_platform = {
         # no A300-specific exceptions
     },
     Platform.DD100: {
-
+        'clearpath_diagnostic_updater: MCU Status': [
+            'No events recorded',
+        ],
+        'clearpath_diagnostic_updater: MCU Firmware Version': [
+            'No firmware version received from MCU',
+        ],
     },
     Platform.DD150: {
-
+        'clearpath_diagnostic_updater: MCU Status': [
+            'No events recorded',
+        ],
+        'clearpath_diagnostic_updater: MCU Firmware Version': [
+            'No firmware version received from MCU',
+        ],
     },
     Platform.DO100: {
-
+        'clearpath_diagnostic_updater: MCU Status': [
+            'No events recorded',
+        ],
+        'clearpath_diagnostic_updater: MCU Firmware Version': [
+            'No firmware version received from MCU',
+        ],
     },
     Platform.DO150: {
-
+        'clearpath_diagnostic_updater: MCU Status': [
+            'No events recorded',
+        ],
+        'clearpath_diagnostic_updater: MCU Firmware Version': [
+            'No firmware version received from MCU',
+        ],
     },
     Platform.GENERIC: {
         # no generic-specific exceptions

--- a/clearpath_tests/clearpath_tests/diagnostic_test.py
+++ b/clearpath_tests/clearpath_tests/diagnostic_test.py
@@ -68,6 +68,9 @@ allowed_errors_by_platform = {
         # no A300-specific exceptions
     },
     Platform.DD100: {
+        'clearpath_diagnostic_updater: Battery Management System': [
+            'Frequency too high',
+        ],
         'clearpath_diagnostic_updater: MCU Status': [
             'No events recorded',
         ],
@@ -76,6 +79,9 @@ allowed_errors_by_platform = {
         ],
     },
     Platform.DD150: {
+        'clearpath_diagnostic_updater: Battery Management System': [
+            'Frequency too high',
+        ],
         'clearpath_diagnostic_updater: MCU Status': [
             'No events recorded',
         ],
@@ -84,6 +90,9 @@ allowed_errors_by_platform = {
         ],
     },
     Platform.DO100: {
+        'clearpath_diagnostic_updater: Battery Management System': [
+            'Frequency too high',
+        ],
         'clearpath_diagnostic_updater: MCU Status': [
             'No events recorded',
         ],
@@ -92,6 +101,9 @@ allowed_errors_by_platform = {
         ],
     },
     Platform.DO150: {
+        'clearpath_diagnostic_updater: Battery Management System': [
+            'Frequency too high',
+        ],
         'clearpath_diagnostic_updater: MCU Status': [
             'No events recorded',
         ],

--- a/clearpath_tests/clearpath_tests/diagnostic_test.py
+++ b/clearpath_tests/clearpath_tests/diagnostic_test.py
@@ -28,6 +28,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 import re
 
+from clearpath_config.common.types.platform import Platform
 from clearpath_generator_common.common import BaseGenerator
 from clearpath_tests.test_node import ClearpathTestNode, ClearpathTestResult
 
@@ -38,15 +39,66 @@ from rclpy.qos import qos_profile_system_default
 from rclpy.time import Duration
 
 
-# Allowed warnings & errors that we can silently drop
-# Key is status.name, value is an array of regexes
-allowed_errors = {
-    'joy_node: Joystick Driver Status': [
-        re.compile(r'.*Joystick not open.*'),
-    ],
-    'controller_manager: Controller Manager Activity': [
-        re.compile(r'Controller Manager has bad periodicity'),
-    ],
+PLATFORM_ANY = '*'
+
+
+# Allowed warnings & errors that we can silently drop on each platform
+# Key is status.name, value is an array of regexes or strings we match against
+allowed_errors_by_platform = {
+    PLATFORM_ANY: {
+        'joy_node: Joystick Driver Status': [
+            re.compile(r'.*Joystick not open.*'),
+        ],
+        'controller_manager: Controller Manager Activity': [
+            'Controller Manager has bad periodicity',
+        ],
+    },
+    Platform.A200: {
+        'clearpath_diagnostic_updater: E-stop Status': [
+            'No events recorded',
+        ],
+        'clearpath_diagnostic_updater: Power Status': [
+            'Frequency too low',
+        ],
+        'clearpath_diagnostic_updater: Battery Management System': [
+            'Frequency too high',
+        ],
+    },
+    Platform.A300: {
+        # no A300-specific exceptions
+    },
+    Platform.DD100: {
+
+    },
+    Platform.DD150: {
+
+    },
+    Platform.DO100: {
+
+    },
+    Platform.DO150: {
+
+    },
+    Platform.GENERIC: {
+
+    },
+    Platform.J100: {
+        'clearpath_diagnostic_updater: Battery Management System': [
+            'Frequency too high',
+        ],
+        'clearpath_diagnostic_updater: MCU Status': [
+            'No events recorded',
+        ],
+        'clearpath_diagnostic_updater: MCU Firmware Version': [
+            'No firmware version received from MCU',
+        ],
+    },
+    Platform.R100: {
+
+    },
+    Platform.W200: {
+
+    },
 }
 
 
@@ -65,10 +117,17 @@ class DiagnosticTestNode(ClearpathTestNode):
 
         if key not in pool.keys():
             allowed = False
-            patterns = allowed_errors.get(status.name, [])
+            patterns = (
+                allowed_errors_by_platform[PLATFORM_ANY].get(status.name, []) +
+                allowed_errors_by_platform[self.clearpath_config.get_platform_model()].get(status.name, [])  # noqa: E501
+            )
             for p in patterns:
-                if re.match(p, status.message):
+                if (
+                    (type(p) is str and p in status.message)
+                    or (type(p) is re.Pattern and re.match(p, status.message))
+                ):
                     allowed = True
+                    break
 
             if not allowed:
                 pool[key] = status

--- a/clearpath_tests/clearpath_tests/diagnostic_test.py
+++ b/clearpath_tests/clearpath_tests/diagnostic_test.py
@@ -94,7 +94,9 @@ allowed_errors_by_platform = {
         ],
     },
     Platform.R100: {
-
+        'clearpath_diagnostic_updater: Battery Management System': [
+            'Frequency too high',
+        ],
     },
     Platform.W200: {
 

--- a/clearpath_tests/clearpath_tests/linear_acceleration_test.py
+++ b/clearpath_tests/clearpath_tests/linear_acceleration_test.py
@@ -27,7 +27,6 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from clearpath_config.common.types.platform import Platform
 from clearpath_generator_common.common import BaseGenerator
 from clearpath_tests.mobility_test import MobilityTestNode
 from clearpath_tests.test_node import ClearpathTestResult


### PR DESCRIPTION
Non-A300 platforms still have some unresolved diagnostic warnings & errors that cause the production tests to fail. These are planned to be fixed in the diagnostic updater in a future release, but for now add them to the allowed list to prevent false-negatives from the production team.

Testing status:
[x] A200
[x] A300
[-] DD100 _not directly tested, but should be identical to DO150_
[-] DD150 _not directly tested, but should be identical to DO150_
[-] DO100 _not directly tested, but should be identical to DO150_
[x] DO150
[x] J100
[x] R100
[ ] W200 _not supported in this version_