### PR TITLE
Reduce strafe distance, increase strafe speed

### DIFF
--- a/clearpath_tests/clearpath_tests/all_tests.py
+++ b/clearpath_tests/clearpath_tests/all_tests.py
@@ -227,7 +227,7 @@ class TestingNode(Node):
                 drive_test.DriveTestNode(
                     setup_path=self.setup_path,
                     default_speed_x=0.0,
-                    default_speed_y=0.1,
+                    default_speed_y=0.2,
                     direction='Left',
                     default_distance=2.0,
                 )

--- a/clearpath_tests/clearpath_tests/all_tests.py
+++ b/clearpath_tests/clearpath_tests/all_tests.py
@@ -181,7 +181,7 @@ class TestingNode(Node):
                 drive_test.DriveTestNode(
                     setup_path=self.setup_path,
                     default_speed_x=0.0,
-                    default_speed_y=0.1,
+                    default_speed_y=0.2,
                     direction='Left',
                     default_distance=2.0,
                 )

--- a/clearpath_tests/clearpath_tests/all_tests.py
+++ b/clearpath_tests/clearpath_tests/all_tests.py
@@ -183,6 +183,7 @@ class TestingNode(Node):
                     default_speed_x=0.0,
                     default_speed_y=0.1,
                     direction='Left',
+                    default_distance=2.0,
                 )
             )
         elif self.platform == Platform.GENERIC:
@@ -228,6 +229,7 @@ class TestingNode(Node):
                     default_speed_x=0.0,
                     default_speed_y=0.1,
                     direction='Left',
+                    default_distance=2.0,
                 )
             )
         elif self.platform == Platform.W200:

--- a/clearpath_tests/clearpath_tests/drive_test.py
+++ b/clearpath_tests/clearpath_tests/drive_test.py
@@ -54,6 +54,7 @@ class DriveTestNode(MobilityTestNode):
         direction='Forwards',
         default_speed_x=0.1,  # 10cm/s; nice and safe
         default_speed_y=0.0,
+        default_distance=5.0,
     ):
         super().__init__(
             f'Drive Fixed Distance ({direction})',
@@ -61,7 +62,7 @@ class DriveTestNode(MobilityTestNode):
             setup_path,
         )
 
-        self.goal_distance = self.get_parameter_or('distance', 5.0)
+        self.goal_distance = self.get_parameter_or('distance', default_distance)
         self.max_speed_x = self.get_parameter_or('max_speed_x', default_speed_x)
         self.max_speed_y = self.get_parameter_or('max_speed_y', default_speed_y)
         self.error_margin = self.get_parameter_or('error_margin', 0.05)  # +/-5%


### PR DESCRIPTION
For omni platforms (Dingo-O, Ridgeback) increase strafe speed test to 0.2 (from 0.1), but reduce the drive distance to 2m. The slightly higher speed seems to mitigate some of the back & forth drift we see with these wheels sometimes.