### PR TITLE
Fix: Increase queue length 

### DIFF
--- a/clearpath_robot/scripts/vcan
+++ b/clearpath_robot/scripts/vcan
@@ -112,7 +112,7 @@ fi
 # All
 if [ "${type}" ==  "virtual" ] || [ "${type}" == "serial" ] || [ "${type}" == "physical" ]; then
   # Increase Tx queue length
-  ip link set $can_dev txqueuelen 100
+  ip link set $can_dev txqueuelen 1000
   sleep 1
 
   # Bring vcan interface up


### PR DESCRIPTION
The transfer queue length must be set to at least 1000 for the `lely_canopen` driver to work. 