### PR TITLE
Fix: Post-Install Permissions

### DIFF
--- a/clearpath_robot/debian/postinst
+++ b/clearpath_robot/debian/postinst
@@ -23,7 +23,8 @@ fi
 if [ -f /lib/systemd/system/clearpath-robot.service ];
 then
     echo "Detected previous installation of clearpath-robot.service. Updating services..."
-    ros2 run clearpath_robot install > /dev/null
+    setpriv --reuid $(get_user) --regid $(get_user) --keep-groups ros2 run clearpath_robot install &
+
 
     # Fix the user in all clearpath-*-start and clearpath-*-stop scripts
     for script in $(ls /usr/sbin/clearpath-*-start);


### PR DESCRIPTION
Use setpriv to call install script in debian post-install