### PR TITLE
Fix/a200 mcu status

### DIFF
--- a/clearpath_hardware_interfaces/src/a200/hardware.cpp
+++ b/clearpath_hardware_interfaces/src/a200/hardware.cpp
@@ -238,8 +238,8 @@ namespace clearpath_hardware_interfaces
       status_msg_.connection_uptime.sec = status_msg_.mcu_uptime.sec;
       status_msg_.connection_uptime.nanosec = status_msg_.mcu_uptime.nanosec;
       // temperature data isn't supported
-      status_msg_.pcb_temperature = NAN;
-      status_msg_.mcu_temperature = NAN;
+      status_msg_.pcb_temperature = std::numeric_limits<double>::quiet_NaN();
+      status_msg_.mcu_temperature = std::numeric_limits<double>::quiet_NaN();
 
       power_msg_.shore_power_connected = clearpath_platform_msgs::msg::Power::NOT_APPLICABLE;
       power_msg_.power_12v_user_nominal = clearpath_platform_msgs::msg::Power::NOT_APPLICABLE;

--- a/clearpath_hardware_interfaces/src/a200/hardware.cpp
+++ b/clearpath_hardware_interfaces/src/a200/hardware.cpp
@@ -232,7 +232,9 @@ namespace clearpath_hardware_interfaces
       horizon_legacy::Channel<clearpath::DataSystemStatus>::requestData(polling_timeout_);
     if (system_status)
     {
-      status_msg_.mcu_uptime = system_status->getUptime();
+      int uptime_ms = system_status->getUptime();  // returns milliseconds!
+      status_msg_.mcu_uptime.sec = uptime_ms / 1000;
+      status_msg_.mcu_uptime.nanosec = (uptime_ms - status_msg_.mcu_uptime.sec * 1000) * 1000000;
 
       power_msg_.shore_power_connected = clearpath_platform_msgs::msg::Power::NOT_APPLICABLE;
       power_msg_.power_12v_user_nominal = clearpath_platform_msgs::msg::Power::NOT_APPLICABLE;

--- a/clearpath_hardware_interfaces/src/a200/hardware.cpp
+++ b/clearpath_hardware_interfaces/src/a200/hardware.cpp
@@ -236,7 +236,10 @@ namespace clearpath_hardware_interfaces
       status_msg_.mcu_uptime.sec = uptime_ms / 1000;
       status_msg_.mcu_uptime.nanosec = (uptime_ms - status_msg_.mcu_uptime.sec * 1000) * 1000000;
       status_msg_.connection_uptime.sec = status_msg_.mcu_uptime.sec;
-      status_msg_.mcu_uptime.nanosec = status_msg_.mcu_uptime.nanosec;
+      status_msg_.connection_uptime.nanosec = status_msg_.mcu_uptime.nanosec;
+      // temperature data isn't supported
+      status_msg_.pcb_temperature = NAN;
+      status_msg_.mcu_temperature = NAN;
 
       power_msg_.shore_power_connected = clearpath_platform_msgs::msg::Power::NOT_APPLICABLE;
       power_msg_.power_12v_user_nominal = clearpath_platform_msgs::msg::Power::NOT_APPLICABLE;
@@ -263,6 +266,7 @@ namespace clearpath_hardware_interfaces
 
     status_msg_.header.frame_id = "base_link";
     status_msg_.header.stamp = status_node_->get_clock()->now();
+    status_msg_.firmware_version = "A200";
     status_msg_.hardware_id = "A200";
 
     status_node_->publish_status(status_msg_);

--- a/clearpath_hardware_interfaces/src/a200/hardware.cpp
+++ b/clearpath_hardware_interfaces/src/a200/hardware.cpp
@@ -235,6 +235,8 @@ namespace clearpath_hardware_interfaces
       int uptime_ms = system_status->getUptime();  // returns milliseconds!
       status_msg_.mcu_uptime.sec = uptime_ms / 1000;
       status_msg_.mcu_uptime.nanosec = (uptime_ms - status_msg_.mcu_uptime.sec * 1000) * 1000000;
+      status_msg_.connection_uptime.sec = status_msg_.mcu_uptime.sec;
+      status_msg_.mcu_uptime.nanosec = status_msg_.mcu_uptime.nanosec;
 
       power_msg_.shore_power_connected = clearpath_platform_msgs::msg::Power::NOT_APPLICABLE;
       power_msg_.power_12v_user_nominal = clearpath_platform_msgs::msg::Power::NOT_APPLICABLE;

--- a/clearpath_hardware_interfaces/src/a200/hardware.cpp
+++ b/clearpath_hardware_interfaces/src/a200/hardware.cpp
@@ -232,7 +232,7 @@ namespace clearpath_hardware_interfaces
       horizon_legacy::Channel<clearpath::DataSystemStatus>::requestData(polling_timeout_);
     if (system_status)
     {
-      // status_msg_.mcu_uptime = system_status->getUptime();
+      status_msg_.mcu_uptime = system_status->getUptime();
 
       power_msg_.shore_power_connected = clearpath_platform_msgs::msg::Power::NOT_APPLICABLE;
       power_msg_.power_12v_user_nominal = clearpath_platform_msgs::msg::Power::NOT_APPLICABLE;
@@ -256,6 +256,10 @@ namespace clearpath_hardware_interfaces
       RCLCPP_ERROR(
         rclcpp::get_logger(HW_NAME), "Could not get system_status");
     }
+
+    status_msg_.header.frame_id = "base_link";
+    status_msg_.header.stamp = status_node_->get_clock()->now();
+    status_msg_.hardware_id = "A200";
 
     status_node_->publish_status(status_msg_);
     status_node_->publish_power(power_msg_);


### PR DESCRIPTION
Populate the A200 MCU status messages.

Before:
```yaml
header:
  stamp:
    sec: 0
    nanosec: 0
  frame_id: ''
hardware_id: ''
firmware_version: ''
mcu_uptime:
  sec: 0
  nanosec: 0
connection_uptime:
  sec: 0
  nanosec: 0
pcb_temperature: 0.0
mcu_temperature: 0.0
```

Now:
```
header:
  stamp:
    sec: 1749064419
    nanosec: 377234028
  frame_id: base_link
hardware_id: A200
firmware_version: A200
mcu_uptime:
  sec: 3694
  nanosec: 320000000
connection_uptime:
  sec: 3694
  nanosec: 320000000
pcb_temperature: .nan
mcu_temperature: .nan
```

Resolves RPPROD-695.

Similar changes to be made for Jazzy in a separate MR.