### PR TITLE
Populate the A200 MCU status messages

### DIFF
--- a/clearpath_hardware_interfaces/src/a200/hardware.cpp
+++ b/clearpath_hardware_interfaces/src/a200/hardware.cpp
@@ -232,7 +232,11 @@ namespace clearpath_hardware_interfaces
       horizon_legacy::Channel<clearpath::DataSystemStatus>::requestData(polling_timeout_);
     if (system_status)
     {
-      // status_msg_.mcu_uptime = system_status->getUptime();
+      int uptime_ms = system_status->getUptime();  // returns milliseconds!
+      status_msg_.mcu_uptime.sec = uptime_ms / 1000;
+      status_msg_.mcu_uptime.nanosec = (uptime_ms - status_msg_.mcu_uptime.sec * 1000) * 1000000;
+      status_msg_.connection_uptime.sec = status_msg_.mcu_uptime.sec;
+      status_msg_.connection_uptime.nanosec = status_msg_.mcu_uptime.nanosec;
 
       power_msg_.shore_power_connected = clearpath_platform_msgs::msg::Power::NOT_APPLICABLE;
       power_msg_.power_12v_user_nominal = clearpath_platform_msgs::msg::Power::NOT_APPLICABLE;
@@ -256,6 +260,11 @@ namespace clearpath_hardware_interfaces
       RCLCPP_ERROR(
         rclcpp::get_logger(HW_NAME), "Could not get system_status");
     }
+
+    status_msg_.header.frame_id = "base_link";
+    status_msg_.header.stamp = status_node_->get_clock()->now();
+    status_msg_.firmware_version = "A200";
+    status_msg_.hardware_id = "A200";
 
     status_node_->publish_status(status_msg_);
     status_node_->publish_power(power_msg_);


### PR DESCRIPTION
Jazzy equivalent to https://github.com/clearpathrobotics/clearpath_robot/pull/223

Update A200 hardware interface to properly populate the A200 MCU status messages:

```yaml
header:
  stamp:
    sec: 1749065260
    nanosec: 980200387
  frame_id: base_link
hardware_id: A200
firmware_version: A200
mcu_uptime:
  sec: 288
  nanosec: 898000000
connection_uptime:
  sec: 288
  nanosec: 898000000
```

Resolves RPPROD-695