### PR TITLE
Fix/Feature: Valence Battery Update/Fix

### DIFF
--- a/clearpath_generator_robot/clearpath_generator_robot/launch/generator.py
+++ b/clearpath_generator_robot/clearpath_generator_robot/launch/generator.py
@@ -155,28 +155,32 @@ class RobotLaunchGenerator(LaunchGenerator):
         if (self.clearpath_config.platform.battery.model in
                 [BatteryConfig.VALENCE_U24_12XP, BatteryConfig.VALENCE_U27_12XP]):
 
-            can_dev = 'can1'
-            bms_id = '0'
-
             launch_args = self.clearpath_config.platform.battery.launch_args
 
-            if launch_args:
-                if 'can_device' in launch_args:
-                    can_dev = launch_args['can_device']
-                if 'bms_id' in launch_args:
-                    bms_id = launch_args['bms_id']
-
-            bms_launch_args = [
-                ('namespace', self.namespace),
-                ('can_device', can_dev),
-                ('bms_id', bms_id),
+            valence_launch_args = [
+                ('namespace', f'{self.namespace}/platform/bms'),
+                ('interface', 'can1'),
+                ('bms_id', '0')
             ]
+
+            for i in range(len(valence_launch_args)):
+                key = valence_launch_args[i][0]
+                if key in launch_args:
+                    val = launch_args[key]
+                    valence_launch_args[i] = (key, str(val))
+
+            self.bms_launch_file = LaunchFile(
+                'valence_bms',
+                filename='bms',
+                package=Package('valence_bms_driver'),
+                args=valence_launch_args
+            )
 
             self.bms_launch_file = LaunchFile(
                 'bms',
                 package=Package('valence_bms_driver'),
-                args=bms_launch_args
-                )
+                args=valence_launch_args
+            )
 
         # Lighting
         self.lighting_node = LaunchFile.Node(

--- a/clearpath_generator_robot/clearpath_generator_robot/launch/generator.py
+++ b/clearpath_generator_robot/clearpath_generator_robot/launch/generator.py
@@ -232,9 +232,12 @@ class RobotLaunchGenerator(LaunchGenerator):
         common_platform_components = [
             self.wireless_watcher_node,
             self.diagnostics_launch,
-            self.battery_state_estimator,
             self.battery_state_control
         ]
+
+        # Only add estimator when no BMS is present
+        if self.bms_launch_file is None:
+            common_platform_components.append(self.battery_state_estimator)
 
         if len(self.can_bridges) > 0:
             common_platform_components.extend(self.can_bridges)

--- a/clearpath_generator_robot/clearpath_generator_robot/launch/generator.py
+++ b/clearpath_generator_robot/clearpath_generator_robot/launch/generator.py
@@ -175,12 +175,6 @@ class RobotLaunchGenerator(LaunchGenerator):
                 args=valence_launch_args
             )
 
-            self.bms_launch_file = LaunchFile(
-                'bms',
-                package=Package('valence_bms_driver'),
-                args=valence_launch_args
-            )
-
         # Lighting
         self.lighting_node = LaunchFile.Node(
           package='clearpath_hardware_interfaces',

--- a/clearpath_generator_robot/clearpath_generator_robot/launch/generator.py
+++ b/clearpath_generator_robot/clearpath_generator_robot/launch/generator.py
@@ -170,8 +170,7 @@ class RobotLaunchGenerator(LaunchGenerator):
                     valence_launch_args[i] = (key, str(val))
 
             self.bms_launch_file = LaunchFile(
-                'valence_bms',
-                filename='bms',
+                'bms',
                 package=Package('valence_bms_driver'),
                 args=valence_launch_args
             )

--- a/clearpath_generator_robot/clearpath_generator_robot/launch/generator.py
+++ b/clearpath_generator_robot/clearpath_generator_robot/launch/generator.py
@@ -158,6 +158,7 @@ class RobotLaunchGenerator(LaunchGenerator):
             launch_args = self.clearpath_config.platform.battery.launch_args
 
             valence_launch_args = [
+                ('robot_namespace', self.namespace),
                 ('namespace', f'{self.namespace}/platform/bms'),
                 ('interface', 'can1'),
                 ('bms_id', '0')


### PR DESCRIPTION
Disable battery estimator when using smart battery (only Valence) 

Update inclusion of Valence battery to have proper namespacing. 