### PR TITLE
Fix expected number of CAN devices on W200

### DIFF
--- a/clearpath_tests/clearpath_tests/all_tests.py
+++ b/clearpath_tests/clearpath_tests/all_tests.py
@@ -234,7 +234,7 @@ class TestingNode(Node):
             )
         elif self.platform == Platform.W200:
             self.tests_for_platform.append(light_test.LightTestNode(4))
-            self.tests_for_platform.append(canbus_test.CanbusTestNode('can0', 4, 0, self.setup_path))  # noqa: E501
+            self.tests_for_platform.append(canbus_test.CanbusTestNode('can0', 6, 0, self.setup_path))  # noqa: E501
 
             self.tests_for_platform.append(estop_test.EstopTestNode('Front Left', self.setup_path))
             self.tests_for_platform.append(estop_test.EstopTestNode('Front Right', self.setup_path))  # noqa: E501


### PR DESCRIPTION
Initial test didn't take the wireless e-stop into account; test passes if the wireless e-stop battery is removed, but fails if the e-stop is powered-on.