### PR TITLE
Feature: systemd Resource Limits

### DIFF
--- a/clearpath_robot/services/clearpath-manipulators.service
+++ b/clearpath_robot/services/clearpath-manipulators.service
@@ -7,6 +7,8 @@ After=clearpath-robot.service
 User=administrator
 Type=simple
 ExecStart=/usr/sbin/clearpath-manipulators-start
+LimitRTPRIO=infinity
+LimitMEMLOCK=infinity
 
 [Install]
 WantedBy=clearpath-robot.service

--- a/clearpath_robot/services/clearpath-platform-extras.service
+++ b/clearpath_robot/services/clearpath-platform-extras.service
@@ -7,6 +7,8 @@ After=clearpath-robot.service
 User=administrator
 Type=simple
 ExecStart=/usr/sbin/clearpath-platform-extras-start
+LimitRTPRIO=infinity
+LimitMEMLOCK=infinity
 
 [Install]
 WantedBy=clearpath-robot.service

--- a/clearpath_robot/services/clearpath-platform.service
+++ b/clearpath_robot/services/clearpath-platform.service
@@ -7,6 +7,8 @@ After=clearpath-robot.service
 User=administrator
 Type=simple
 ExecStart=/usr/sbin/clearpath-platform-start
+LimitRTPRIO=infinity
+LimitMEMLOCK=infinity
 
 [Install]
 WantedBy=clearpath-robot.service

--- a/clearpath_robot/services/clearpath-sensors.service
+++ b/clearpath_robot/services/clearpath-sensors.service
@@ -7,6 +7,8 @@ After=clearpath-robot.service
 User=administrator
 Type=simple
 ExecStart=/usr/sbin/clearpath-sensors-start
+LimitRTPRIO=infinity
+LimitMEMLOCK=infinity
 
 [Install]
 WantedBy=clearpath-robot.service


### PR DESCRIPTION
Remove limits on RTPrio and MEMLock in `systemd` services. 

Services are by default resource locked, however, if ran as `root`, these services have unrestricted access to resources such as scheduling priority and locking memory in place.

When running services as a non `root` user, the default resource locks apply unless explicitly overwritten.  These default resource limits can be defined system wide using the `/etc/systemd/system.conf`, but by default this file is empty and all limits are unset. This does not mean that by default these resources are unrestricted, instead these limits fall to the kernel and operating system. 

Therefore, every service that might run processes that require real-time scheduling or locked-in-memory, such as the `ros2_control` controller or manipulator communication, needs to have these resources unrestricted. 

