### PR TITLE
Catch FileNotFound exceptions when loading samples

### DIFF
--- a/clearpath_generator_robot/test/test_generator_launch.py
+++ b/clearpath_generator_robot/test/test_generator_launch.py
@@ -57,6 +57,8 @@ class TestRobotLaunchGenerator:
                 print(f'Unsupported accessory: {e}')
             except UnsupportedPlatformException as e:
                 print(f'Unsupported platform: {e}')
+            except FileNotFoundError as e:
+                print(f'File not found: {e}')
             except Exception as e:
                 errors.append("Sample '%s' failed to load: '%s'" % (
                     sample,

--- a/clearpath_generator_robot/test/test_generator_param.py
+++ b/clearpath_generator_robot/test/test_generator_param.py
@@ -61,6 +61,8 @@ class TestRobotLaunchGenerator:
                 print(f'Unsupported accessory: {e}')
             except UnsupportedPlatformException as e:
                 print(f'Unsupported platform: {e}')
+            except FileNotFoundError as e:
+                print(f'File not found: {e}')
             except Exception as e:
                 errors.append("Sample '%s' failed to load: '%s'" % (
                     sample,


### PR DESCRIPTION
Catch FileNotFound exceptions when loading the samples and ignore them; some samples have `/path/to/...` placeholders, which will never load correctly