### PR TITLE
Generate peplink launches

### DIFF
--- a/clearpath_generator_robot/clearpath_generator_robot/launch/generator.py
+++ b/clearpath_generator_robot/clearpath_generator_robot/launch/generator.py
@@ -164,6 +164,7 @@ class RobotLaunchGenerator(LaunchGenerator):
                             self.clearpath_config.platform.wireless.router.publish_passwords,
                     }
                 ],
+                remappings=[('/diagnostics', 'diagnostics'),],
             )
         else:
             self.wireless_router_node = None
@@ -187,6 +188,7 @@ class RobotLaunchGenerator(LaunchGenerator):
                             self.clearpath_config.platform.wireless.base_station.publish_passwords,
                     }
                 ],
+                remappings=[('/diagnostics', 'diagnostics'),],
             )
         else:
             self.base_station_node = None

--- a/clearpath_generator_robot/clearpath_generator_robot/launch/generator.py
+++ b/clearpath_generator_robot/clearpath_generator_robot/launch/generator.py
@@ -44,6 +44,7 @@ from clearpath_config.manipulators.types.arms import (
 )
 from clearpath_config.manipulators.types.grippers import FrankaGripper
 from clearpath_config.platform.battery import BatteryConfig
+from clearpath_config.platform.wireless import PeplinkRouter
 from clearpath_generator_common.common import LaunchFile, Package
 from clearpath_generator_common.launch.generator import LaunchGenerator
 from clearpath_generator_common.launch.writer import LaunchWriter
@@ -141,6 +142,54 @@ class RobotLaunchGenerator(LaunchGenerator):
             ],
             remappings=[('/diagnostics', 'diagnostics'),],
         )
+
+        # Onboard router & base station
+        if isinstance(self.clearpath_config.platform.wireless.router, PeplinkRouter):
+            self.wireless_router_node = LaunchFile.Node(
+                package='peplink_router_driver',
+                executable='peplink_router_node',
+                name='router_node',
+                namespace=f'{self.namespace}/network/router',
+                parameters=[
+                    {
+                        'ip_address':
+                            self.clearpath_config.platform.wireless.router.ip_address,
+                        'username':
+                            self.clearpath_config.platform.wireless.router.username,
+                        'password':
+                            self.clearpath_config.platform.wireless.router.password,
+                        'enable_gps':
+                            self.clearpath_config.platform.wireless.router.enable_gps,
+                        'publish_passwords':
+                            self.clearpath_config.platform.wireless.router.publish_passwords,
+                    }
+                ],
+            )
+        else:
+            self.wireless_router_node = None
+        if isinstance(self.clearpath_config.platform.wireless.base_station, PeplinkRouter):
+            self.base_station_node = LaunchFile.Node(
+                package='peplink_router_driver',
+                executable='peplink_router_node',
+                name='base_station_node',
+                namespace=f'{self.namespace}/network/base_station',
+                parameters=[
+                    {
+                        'ip_address':
+                            self.clearpath_config.platform.wireless.base_station.ip_address,
+                        'username':
+                            self.clearpath_config.platform.wireless.base_station.username,
+                        'password':
+                            self.clearpath_config.platform.wireless.base_station.password,
+                        'enable_gps':
+                            self.clearpath_config.platform.wireless.base_station.enable_gps,
+                        'publish_passwords':
+                            self.clearpath_config.platform.wireless.base_station.publish_passwords,
+                    }
+                ],
+            )
+        else:
+            self.base_station_node = None
 
         # Diagnostics launch args
         self.diag_updater_params = LaunchFile.LaunchArg(
@@ -395,8 +444,20 @@ class RobotLaunchGenerator(LaunchGenerator):
         if self.bms_launch_file is None and self.bms_node is None:
             common_platform_components.append(self.battery_state_estimator)
 
-        if self.clearpath_config.platform.enable_wireless_watcher:
+        if self.clearpath_config.platform.wireless.enable_wireless_watcher:
             common_platform_components.append(self.wireless_watcher_node)
+        if (
+            self.wireless_router_node is not None
+            and self.clearpath_config.platform.wireless.router is not None
+            and self.clearpath_config.platform.wireless.router.launch_enabled
+        ):
+            common_platform_components.append(self.wireless_router_node)
+        if (
+            self.base_station_node is not None
+            and self.clearpath_config.platform.wireless.base_station is not None
+            and self.clearpath_config.platform.wireless.base_station.launch_enabled
+        ):
+            common_platform_components.append(self.base_station_node)
 
         if len(self.can_bridges) > 0:
             common_platform_components.extend(self.can_bridges)

--- a/clearpath_generator_robot/package.xml
+++ b/clearpath_generator_robot/package.xml
@@ -20,6 +20,7 @@
   <exec_depend>imu_filter_madgwick</exec_depend>
   <exec_depend>canopen_inventus_bringup</exec_depend>
   <exec_depend>micro_ros_agent</exec_depend>
+  <exec_depend>peplink_router_driver</exec_depend>
   <exec_depend>python3-apt</exec_depend>
   <exec_depend>sevcon_traction</exec_depend>
   <exec_depend>valence_bms_driver</exec_depend>


### PR DESCRIPTION
Use the new `platform.wireless` section for wireless watcher, peplink router generation.

Currently only peplink devices are supported, but the code is designed to be expandable in the future.

See:
- https://github.com/clearpathrobotics/clearpath_config/pull/201
- https://github.com/clearpathrobotics/clearpath_common/pull/272