### PR TITLE
Removed ROS Industrial CI job.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,19 +7,6 @@ on:
     - cron: "0 0 * * *" # every day at midnight
 
 jobs:
-  clearpath_robot_osrf_industrial_ci:
-    name: Jazzy OSRF Industrial
-    strategy:
-      matrix:
-        env:
-          - {ROS_REPO: testing, ROS_DISTRO: jazzy, ROSDEP_SKIP_KEYS: "canopen_inventus_bringup micro_ros_agent sevcon_traction umx_driver valence_bms_driver wiferion_charger"}
-          - {ROS_REPO: main, ROS_DISTRO: jazzy, ROSDEP_SKIP_KEYS: "canopen_inventus_bringup micro_ros_agent sevcon_traction umx_driver valence_bms_driver wiferion_charger"}
-      fail-fast: false
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v3
-      - uses: 'ros-industrial/industrial_ci@master'
-        env: ${{matrix.env}}
   clearpath_robot_cpr_ci:
     name: Jazzy Clearpath Release
     runs-on: ubuntu-24.04


### PR DESCRIPTION
The ROS Industrial CI job will always fail now due to a `build_dep`.