### PR TITLE
WIP: CORE-36183: [puma motor driver] CAN adaptor implementation

### DIFF
--- a/clearpath_motor_drivers/puma_motor_driver/CMakeLists.txt
+++ b/clearpath_motor_drivers/puma_motor_driver/CMakeLists.txt
@@ -32,7 +32,7 @@ add_executable(multi_puma_node
 target_include_directories(multi_puma_node PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include/${PROJECT_NAME}>)
-target_compile_features(multi_puma_node PUBLIC c_std_99 cxx_std_17)  # Require C99 and C++17
+target_compile_features(multi_puma_node PUBLIC c_std_99 cxx_std_20)  # Require C99 and C++20
 
 ament_target_dependencies(multi_puma_node ${DEPENDENCIES})
 target_link_libraries(multi_puma_node)

--- a/clearpath_motor_drivers/puma_motor_driver/include/puma_motor_driver/can_interface.hpp
+++ b/clearpath_motor_drivers/puma_motor_driver/include/puma_motor_driver/can_interface.hpp
@@ -1,0 +1,20 @@
+/**
+Software License Agreement (proprietary)
+
+\file      can_interface.hpp
+\authors   Natesh Narain <nnarain@clearpath.ai>
+\copyright Copyright (c) 2025, Rockwell Automation Technologies, Inc., All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, is not permitted without the
+express permission of Rockwell Automation Technologies.
+*/
+
+#ifndef PUMA_MOTOR_DRIVER_CAN_INTERFACE_H
+#define PUMA_MOTOR_DRIVER_CAN_INTERFACE_H
+
+#include <can_hardware/drivers/socketcan_driver.hpp>
+#include <can_hardware/adaptors/can/connection.hpp>
+
+using CanConnection = can_hardware::adaptor::Connection<can_hardware::drivers::SocketCanDriver>;
+
+#endif // PUMA_MOTOR_DRIVER_CAN_INTERFACE_H

--- a/clearpath_motor_drivers/puma_motor_driver/include/puma_motor_driver/driver.hpp
+++ b/clearpath_motor_drivers/puma_motor_driver/include/puma_motor_driver/driver.hpp
@@ -26,31 +26,34 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
 
 #include <stdint.h>
 #include <string>
+#include <queue>
+#include <mutex>
+#include <type_traits>
 
 #include <rclcpp/rclcpp.hpp>
 
 #include "can_hardware/common/types.hpp"
-#include "can_hardware/drivers/socketcan_driver.hpp"
+#include "can_hardware/adaptors/can/can_adaptor.hpp"
+
 
 #include "clearpath_motor_msgs/msg/puma_status.hpp"
 
 #include "diagnostic_updater/update_functions.hpp"
 
 #include "puma_motor_driver/can_proto.hpp"
+#include "puma_motor_driver/can_interface.hpp"
 
 namespace puma_motor_driver
 {
 
-class Driver
+class Driver : public can_hardware::adaptor::CanAdaptor
 {
 public:
   Driver(
-    const std::shared_ptr<can_hardware::drivers::SocketCanDriver> interface,
+    CanConnection* conn,
     std::shared_ptr<rclcpp::Node> nh,
     const uint8_t & device_number,
     const std::string & device_name);
-
-  void processMessage(const can_hardware::Frame & frame);
 
   double radPerSecToRpm() const;
 
@@ -97,11 +100,6 @@ public:
    */
   void requestFeedbackSetpoint();
   /**
-   * Clear the received flags from the status cache, in preparation for the next
-   * request batch to go out.
-   */
-  void clearMsgCache();
-  /**
    * Command the supplied value in open-loop voltage control.
    *
    * @param[in] cmd Value to command, ranging from -1.0 to 1.0, where zero is neutral.
@@ -113,9 +111,6 @@ public:
    * @param[in] cmd Value to command in rad/s.
    */
   void commandSpeed(const double cmd);
-  // void currentSet(float cmd);
-  // void positionSet(float cmd);
-  // void neutralSet();
 
   /**
    * Set the encoders resolution in counts per rev.
@@ -397,23 +392,23 @@ public:
    * Process the last received P gain
    * for the current control mode.
    *
-   * @return pointer to raw 4 bytes of the P gain response.
+   * @return Value of the P gain response.
    */
-  uint8_t * getRawP();
+  double getRawP();
   /**
    * Process the last received I gain
    * for the current control mode.
    *
-   * @return pointer to raw 4 bytes of the I gain response.
+   * @return Value of the I gain response.
    */
-  uint8_t * getRawI();
+  double getRawI();
   /**
    * Process the last received I gain
    * for the current control mode.
    *
-   * @return pointer to raw 4 bytes of the I gain response.
+   * @return Value of the I gain response.
    */
-  uint8_t * getRawD();
+  double getRawD();
   /**
    * Process the last received set-point response
    * in voltage open-loop control.
@@ -468,8 +463,18 @@ public:
   void runFreqStatus(diagnostic_updater::DiagnosticStatusWrapper & stat);
   void driverUpdateDiagnostics(diagnostic_updater::DiagnosticStatusWrapper & stat, bool updating);
 
+  can_hardware::Frame createRequestReadFrame(const can_hardware::CanId id) override
+  {
+    // Override the CAN adaptor's default read request frame creation that uses RTR frames.
+
+    can_hardware::Frame frame;
+    frame.id = id;
+    frame.is_extended = true;
+    frame.dlc = 0;
+    return frame;
+  }
+
 private:
-  std::shared_ptr<can_hardware::drivers::SocketCanDriver> interface_;
   std::shared_ptr<rclcpp::Node> nh_;
   uint8_t device_number_;
   std::string device_name_;
@@ -485,49 +490,153 @@ private:
   uint16_t encoder_cpr_;
   float gear_ratio_;
 
-  /**
-   * Helpers to generate data for CAN messages.
-   */
-  void sendId(const uint32_t id);
-  void sendUint8(const uint32_t id, const uint8_t value);
-  void sendUint16(const uint32_t id, const uint16_t value);
-  void sendFixed8x8(const uint32_t id, const float value);
-  void sendFixed16x16(const uint32_t id, const double value);
-  can_hardware::Frame getMsg(const uint32_t id);
-  uint32_t getApi(const can_hardware::Frame & msg);
-  uint32_t getDeviceNumber(const can_hardware::Frame & msg);
+  std::queue<can_hardware::Frame> message_queue_;
+  std::mutex message_queue_mutex_;
+  std::set<std::string> signals_;
 
-  /**
-   * Comparing the raw bytes of the 16x16 fixed-point numbers
-    * to avoid comparing the floating point values.
-   *
-   * @return boolean if received is equal to expected.
-   */
-  bool verifyRaw16x16(const uint8_t * received, const double expected);
+  template<typename T>
+  class Signal
+  {
+  public:
+    using Ptr = std::unique_ptr<Signal<T>>;
 
-  /**
-   * Comparing the raw bytes of the 8x8 fixed-point numbers
-    * to avoid comparing the floating point values.
-   *
-   * @return boolean if received is equal to expected.
-   */
-  bool verifyRaw8x8(const uint8_t * received, const float expected);
+    Signal() = default;
 
-  Field voltage_fields_[4];
-  Field spd_fields_[7];
-  Field vcomp_fields_[5];
-  Field pos_fields_[7];
-  Field ictrl_fields_[6];
-  Field status_fields_[15];
-  Field cfg_fields_[15];
+    Signal(const std::string& name, SignalAdaptor& adaptor)
+      : name(name), adaptor(adaptor)
+    {
+    }
+    ~Signal() = default;
 
-  Field * voltageFieldForMessage(uint32_t api);
-  Field * spdFieldForMessage(uint32_t api);
-  Field * vcompFieldForMessage(uint32_t api);
-  Field * posFieldForMessage(uint32_t api);
-  Field * ictrlFieldForMessage(uint32_t api);
-  Field * statusFieldForMessage(uint32_t api);
-  Field * cfgFieldForMessage(uint32_t api);
+    void requestRead()
+    {
+      adaptor.get().requestRead(name);
+    }
+
+    void requestWrite(const T& value)
+    {
+      adaptor.get().requestWrite(name, value);
+    }
+
+    T value() const
+    {
+      return adaptor.get().template getSignalAs<T>(name);
+    }
+
+    bool received() const
+    {
+      return !hal::is_none(adaptor.get().getSignal(name));
+    }
+
+    bool isNone() const
+    {
+      return hal::is_none(adaptor.get().getSignal(name));
+    }
+
+  public:
+    //! The name of the signal
+    std::string name;
+    
+  private:
+    //! Reference to the signal adaptor
+    std::reference_wrapper<SignalAdaptor> adaptor;
+  };
+
+  template<typename T>
+  Signal<T>::Ptr registerSignal(const std::string& name, const can_hardware::CanId id, uint8_t device_number)
+  {
+    constexpr uint32_t bit_offset = 0;
+    constexpr uint32_t byte_length = 4;
+    constexpr uint32_t bit_length = byte_length * 8;
+
+    if constexpr (std::is_integral<T>::value && std::is_unsigned<T>::value)
+    {
+      addSignal<T>(name, bit_offset, bit_length, false, 1.0, 0, std::endian::little);
+    }
+    else if constexpr (std::is_integral<T>::value && std::is_signed<T>::value)
+    {
+      addSignal<T>(name, bit_offset, bit_length, true, 1.0, 0, std::endian::little);
+    }
+    else if constexpr (std::is_same<T, double>::value)
+    {
+      // Fixed-point 16x16 representation
+      addSignal<T>(name, bit_offset, bit_length, true, 1.0 / static_cast<double>(1 << 16), 0, std::endian::little);
+    }
+    else if constexpr (std::is_same<T, float>::value)
+    {
+      // Fixed-point 8x8 representation
+      addSignal<T>(name, bit_offset, bit_length, true, 1.0 / static_cast<float>(1 << 8), 0, std::endian::little);
+    }
+    else
+    {
+      // Trigger a compile-time error for unsupported types
+      static_assert(sizeof(T) == 0, "Unsupported signal type");
+    }
+
+    const can_hardware::CanId full_id = id | (device_number & CAN_MSGID_DEVNO_M);
+    // Register the signal to a CAN frame with it associated CAN ID
+    addRxSignals(full_id, {name});
+    // Register the signal for on request transmission (rate=0.0)
+    addTxSignals(full_id, byte_length, true, false, {name}, 0.0);
+
+    signals_.insert(name);
+
+    return std::make_unique<Signal<T>>(name, *this);
+  }
+
+
+  bool verify(const double recv, const double expected) const
+  {
+    return std::abs(recv - expected) < 1e-4;  // Allow for fixed-point quantization
+  }
+
+  // Voltage control Signals
+  Signal<uint8_t>::Ptr voltage_enable_;
+  Signal<uint8_t>::Ptr voltage_disable_;
+  Signal<float>::Ptr voltage_set_;
+  Signal<float>::Ptr voltage_set_ramp_;
+
+  // Status Signals
+  Signal<float>::Ptr status_voltage_out_;
+  Signal<float>::Ptr status_voltage_bus_;
+  Signal<float>::Ptr status_current_;
+  Signal<double>::Ptr status_speed_;
+  Signal<uint32_t>::Ptr status_limit_;
+  Signal<float>::Ptr status_temperature_;
+  Signal<double>::Ptr status_position_;
+  Signal<uint8_t>::Ptr status_power_;
+  Signal<uint8_t>::Ptr status_control_mode_;
+  Signal<float>::Ptr status_vout_;
+  Signal<float>::Ptr status_analog_;
+  Signal<uint8_t>::Ptr status_fault_;
+  Signal<uint32_t>::Ptr status_sticky_fault_;
+  Signal<uint32_t>::Ptr status_fault_count_;
+
+  // Position Control Signals
+  Signal<uint32_t>::Ptr position_enable_;
+  Signal<uint32_t>::Ptr position_disable_;
+  Signal<double>::Ptr position_set_;
+  Signal<uint8_t>::Ptr position_ref_;
+  Signal<double>::Ptr position_pc_;
+  Signal<double>::Ptr position_ic_;
+  Signal<double>::Ptr position_dc_;
+  // Speed Control Signals
+  Signal<uint8_t>::Ptr speed_enable_;
+  Signal<uint8_t>::Ptr speed_disable_;
+  Signal<double>::Ptr speed_set_;
+  Signal<double>::Ptr speed_pc_;
+  Signal<double>::Ptr speed_ic_;
+  Signal<double>::Ptr speed_dc_;
+  Signal<uint8_t>::Ptr speed_ref_;
+  // Current Control Signals
+  Signal<uint32_t>::Ptr ictrl_enable_;
+  Signal<uint32_t>::Ptr ictrl_disable_;
+  Signal<float>::Ptr ictrl_set_;
+  Signal<double>::Ptr ictrl_pc_;
+  Signal<double>::Ptr ictrl_ic_;
+  Signal<double>::Ptr ictrl_dc_;
+  // Configuration Signals
+  Signal<uint16_t>::Ptr cfg_enc_lines_;
 
   // Frequency Status for diagnostics
   std::shared_ptr<double> can_feedback_rate_; // Shared ptr prevents copy errors of FrequencyStatus

--- a/clearpath_motor_drivers/puma_motor_driver/include/puma_motor_driver/multi_puma_node.hpp
+++ b/clearpath_motor_drivers/puma_motor_driver/include/puma_motor_driver/multi_puma_node.hpp
@@ -38,10 +38,10 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
 #include "clearpath_motor_msgs/msg/puma_feedback.hpp"
 
 #include "can_hardware/common/types.hpp"
-#include "can_hardware/drivers/socketcan_driver.hpp"
 
 #include "diagnostic_updater/diagnostic_updater.hpp"
 
+#include "puma_motor_driver/can_interface.hpp"
 #include "puma_motor_driver/driver.hpp"
 // #include "puma_motor_driver/diagnostic_updater.hpp"
 
@@ -138,9 +138,8 @@ private:
   using DiagnosticStatusWrapper = diagnostic_updater::DiagnosticStatusWrapper;
   using PumaStatus = clearpath_motor_msgs::msg::PumaStatus;
 
-  // std::shared_ptr<clearpath_ros2_socketcan_interface::SocketCANInterface> interface_;
-  std::shared_ptr<can_hardware::drivers::SocketCanDriver> interface_;
-  std::vector<puma_motor_driver::Driver> drivers_;
+  std::unique_ptr<CanConnection> interface_;
+  std::vector<std::unique_ptr<puma_motor_driver::Driver>> drivers_;
 
   bool active_;
   double gear_ratio_;

--- a/clearpath_motor_drivers/puma_motor_driver/src/driver.cpp
+++ b/clearpath_motor_drivers/puma_motor_driver/src/driver.cpp
@@ -58,11 +58,11 @@ enum ConfigurationState
 typedef ConfigurationStates::ConfigurationState ConfigurationState;
 
 Driver::Driver(
-  const std::shared_ptr<can_hardware::drivers::SocketCanDriver> interface,
+  CanConnection* conn,
   std::shared_ptr<rclcpp::Node> nh,
   const uint8_t & device_number,
   const std::string & device_name)
-: interface_(interface),
+: can_hardware::adaptor::CanAdaptor(device_name, conn),
   nh_(nh),
   device_number_(device_number),
   device_name_(device_name),
@@ -76,6 +76,81 @@ Driver::Driver(
   encoder_cpr_(1),
   gear_ratio_(1)
 {
+
+  // Register Signals
+
+  // Voltage Control Signals (voltage_fields_[4]):
+  voltage_enable_   = registerSignal<uint8_t>("voltage_enable",   LM_API_VOLT_EN,       device_number_);
+  voltage_disable_  = registerSignal<uint8_t>("voltage_disable", LM_API_VOLT_DIS,      device_number_);
+  voltage_set_      = registerSignal<float>("voltage_set",      LM_API_VOLT_SET,      device_number_);
+  voltage_set_ramp_ = registerSignal<float>("voltage_set_ramp", LM_API_VOLT_SET_RAMP, device_number_);
+
+  // Speed Control Signals (spd_fields_[7]):
+  speed_enable_  = registerSignal<uint8_t>("speed_enable",    LM_API_SPD_EN,  device_number_);
+  speed_disable_ = registerSignal<uint8_t>("speed_disable",   LM_API_SPD_DIS, device_number_);
+  speed_set_     = registerSignal<double>("speed_set",        LM_API_SPD_SET, device_number_);
+  speed_pc_      = registerSignal<double>("speed_pc",         LM_API_SPD_PC,  device_number_);
+  speed_ic_      = registerSignal<double>("speed_ic",         LM_API_SPD_IC,  device_number_);
+  speed_dc_      = registerSignal<double>("speed_dc",         LM_API_SPD_DC,  device_number_);
+  speed_ref_     = registerSignal<uint8_t>("speed_ref",       LM_API_SPD_REF, device_number_);
+  // Voltage Compensation Signals (vcomp_fields_[5]):
+  (void)registerSignal<uint32_t>("vcomp_enable",   LM_API_VCOMP_EN, device_number_);
+  (void)registerSignal<uint32_t>("vcomp_disable",  LM_API_VCOMP_DIS, device_number_);
+  (void)registerSignal<int32_t>("vcomp_set",       LM_API_VCOMP_SET, device_number_);
+  (void)registerSignal<int32_t>("vcomp_in_ramp",   LM_API_VCOMP_IN_RAMP, device_number_);
+  (void)registerSignal<int32_t>("vcomp_comp_ramp", LM_API_VCOMP_COMP_RAMP, device_number_);
+
+  // Position Control Signals (pos_fields_[7]):
+  position_enable_  = registerSignal<uint32_t>("position_enable",  LM_API_POS_EN, device_number_);
+  position_disable_ = registerSignal<uint32_t>("position_disable", LM_API_POS_DIS, device_number_);
+  position_set_     = registerSignal<double>("position_set",      LM_API_POS_SET, device_number_);
+  position_pc_      = registerSignal<double>("position_pc",        LM_API_POS_PC, device_number_);
+  position_ic_      = registerSignal<double>("position_ic",        LM_API_POS_IC, device_number_);
+  position_dc_      = registerSignal<double>("position_dc",        LM_API_POS_DC, device_number_);
+  position_ref_     = registerSignal<uint8_t>("position_ref",      LM_API_POS_REF, device_number_);
+
+  // Current Control Signals (ictrl_fields_[6]):
+  ictrl_enable_  = registerSignal<uint32_t>("ictrl_enable",  LM_API_ICTRL_EN, device_number_);
+  ictrl_disable_ = registerSignal<uint32_t>("ictrl_disable", LM_API_ICTRL_DIS, device_number_);
+  ictrl_set_     = registerSignal<float>("ictrl_set",      LM_API_ICTRL_SET, device_number_);
+  ictrl_pc_      = registerSignal<double>("ictrl_pc",        LM_API_ICTRL_PC, device_number_);
+  ictrl_ic_      = registerSignal<double>("ictrl_ic",        LM_API_ICTRL_IC, device_number_);
+  ictrl_dc_      = registerSignal<double>("ictrl_dc",        LM_API_ICTRL_DC, device_number_);
+
+  // Status Signals (status_fields_[15]):
+  status_voltage_out_  = registerSignal<float>("status_voltage_out",     LM_API_STATUS_VOLTOUT, device_number_);
+  status_voltage_bus_  = registerSignal<float>("status_voltage_bus",   LM_API_STATUS_VOLTBUS, device_number_);
+  status_current_      = registerSignal<float>("status_current",       LM_API_STATUS_CURRENT, device_number_);
+  status_temperature_  = registerSignal<float>("status_temperature",   LM_API_STATUS_TEMP, device_number_);
+  status_position_     = registerSignal<double>("status_position",      LM_API_STATUS_POS, device_number_);
+  status_speed_        = registerSignal<double>("status_speed",         LM_API_STATUS_SPD, device_number_);
+  status_limit_        = registerSignal<uint32_t>("status_limit",        LM_API_STATUS_LIMIT, device_number_);
+  status_fault_        = registerSignal<uint8_t>("status_fault",        LM_API_STATUS_FAULT, device_number_);
+  status_power_        = registerSignal<uint8_t>("status_power",         LM_API_STATUS_POWER, device_number_);
+  status_control_mode_ = registerSignal<uint8_t>("status_control_mode",  LM_API_STATUS_CMODE, device_number_);
+  status_vout_         = registerSignal<float>("status_vout",          LM_API_STATUS_VOUT, device_number_);
+  status_sticky_fault_ = registerSignal<uint32_t>("status_sticky_fault", LM_API_STATUS_STKY_FLT, device_number_);
+  status_fault_count_  = registerSignal<uint32_t>("status_fault_count",  LM_API_STATUS_FLT_COUNT, device_number_);
+  status_analog_       = registerSignal<float>("status_analog",        CPR_API_STATUS_ANALOG, device_number_);
+
+  // Configuration Signals (cfg_fields_[15]):
+  (void)registerSignal<uint32_t>("cfg_num_brushes",          LM_API_CFG_NUM_BRUSHES, device_number_);
+  cfg_enc_lines_ = registerSignal<uint16_t>("cfg_enc_lines", LM_API_CFG_ENC_LINES, device_number_);
+  (void)registerSignal<uint32_t>("cfg_pot_turns",            LM_API_CFG_POT_TURNS, device_number_);
+  (void)registerSignal<uint32_t>("cfg_brake_coast",          LM_API_CFG_BRAKE_COAST, device_number_);
+  (void)registerSignal<uint32_t>("cfg_limit_mode",           LM_API_CFG_LIMIT_MODE, device_number_);
+  (void)registerSignal<int32_t>("cfg_limit_fwd",             LM_API_CFG_LIMIT_FWD, device_number_);
+  (void)registerSignal<int32_t>("cfg_limit_rev",             LM_API_CFG_LIMIT_REV, device_number_);
+  (void)registerSignal<uint32_t>("cfg_max_vout",             LM_API_CFG_MAX_VOUT, device_number_);
+  (void)registerSignal<uint32_t>("cfg_fault_time",           LM_API_CFG_FAULT_TIME, device_number_);
+  (void)registerSignal<uint32_t>("cfg_shutdown_temp",        CPR_API_CFG_SHUTDOWN_TEMP, device_number_);
+  (void)registerSignal<uint32_t>("cfg_minimum_level",        CPR_API_CFG_MINIMUM_LEVEL, device_number_);
+  (void)registerSignal<uint32_t>("cfg_nominal_level",        CPR_API_CFG_NOMINAL_LEVEL, device_number_);
+  (void)registerSignal<uint32_t>("cfg_shutoff_level",        CPR_API_CFG_SHUTOFF_LEVEL, device_number_);
+  (void)registerSignal<uint32_t>("cfg_shutoff_time",         CPR_API_CFG_SHUTOFF_TIME, device_number_);
+
+  RCLCPP_INFO(nh_->get_logger(), "Puma Motor Driver initialized signals for device %s with ID %d", device_name_.c_str(), device_number_);
+
   can_feedback_rate_ = std::make_shared<double>(CAN_FEEDBACK_RATE);
   can_feedback_freq_status_ = std::make_shared<diagnostic_updater::FrequencyStatus>(
     diagnostic_updater::FrequencyStatusParam(
@@ -87,155 +162,9 @@ Driver::Driver(
   );
 }
 
-void Driver::processMessage(const can_hardware::Frame & received_msg)
-{
-  // If it's not our message, jump out.
-  if (getDeviceNumber(received_msg) != device_number_) {
-    return;
-  }
-
-  // If there's no data then this is a request message, jump out.
-  if (received_msg.dlc == 0) {
-    return;
-  }
-
-  Field * field = nullptr;
-  uint32_t received_api = getApi(received_msg);
-  if ((received_api & CAN_MSGID_API_M & CAN_API_MC_CFG) == CAN_API_MC_CFG) {
-    field = cfgFieldForMessage(received_api);
-  } else if ((received_api & CAN_MSGID_API_M & CAN_API_MC_STATUS) == CAN_API_MC_STATUS) {
-    field = statusFieldForMessage(received_api);
-  } else if ((received_api & CAN_MSGID_API_M & CAN_API_MC_ICTRL) == CAN_API_MC_ICTRL) {
-    field = ictrlFieldForMessage(received_api);
-    can_feedback_freq_status_->tick();
-  } else if ((received_api & CAN_MSGID_API_M & CAN_API_MC_POS) == CAN_API_MC_POS) {
-    field = posFieldForMessage(received_api);
-    can_feedback_freq_status_->tick();
-  } else if ((received_api & CAN_MSGID_API_M & CAN_API_MC_VCOMP) == CAN_API_MC_VCOMP) {
-    field = vcompFieldForMessage(received_api);
-    can_feedback_freq_status_->tick();
-  } else if ((received_api & CAN_MSGID_API_M & CAN_API_MC_SPD) == CAN_API_MC_SPD) {
-    field = spdFieldForMessage(received_api);
-    can_feedback_freq_status_->tick();
-  } else if ((received_api & CAN_MSGID_API_M & CAN_API_MC_VOLTAGE) == CAN_API_MC_VOLTAGE) {
-    field = voltageFieldForMessage(received_api);
-    can_feedback_freq_status_->tick();
-  }
-
-  if (!field) {
-    return;
-  }
-
-  // Copy the received data and mark that field as received.
-  std::copy_n(std::begin(received_msg.data), Field::FIELD_STRUCT_DATA_SIZE,
-    std::begin(field->data));
-  field->received = true;
-}
-
 double Driver::radPerSecToRpm() const
 {
   return (60 * gear_ratio_) / (2 * M_PI);
-}
-
-void Driver::sendId(const uint32_t id)
-{
-  auto msg = getMsg(id);
-  interface_->sendFrame(msg);
-}
-
-void Driver::sendUint8(const uint32_t id, const uint8_t value)
-{
-  auto msg = getMsg(id);
-  msg.dlc = sizeof(uint8_t);
-  uint8_t data[8] = {0};
-  std::memcpy(data, &value, sizeof(uint8_t));
-  std::copy(std::begin(data), std::end(data), std::begin(msg.data));
-
-  interface_->sendFrame(msg);
-}
-
-void Driver::sendUint16(const uint32_t id, const uint16_t value)
-{
-  auto msg = getMsg(id);
-  msg.dlc = sizeof(uint16_t);
-  uint8_t data[8] = {0};
-  std::memcpy(data, &value, sizeof(uint16_t));
-  std::copy(std::begin(data), std::end(data), std::begin(msg.data));
-
-  interface_->sendFrame(msg);
-}
-
-void Driver::sendFixed8x8(const uint32_t id, const float value)
-{
-  auto msg = getMsg(id);
-  msg.dlc = sizeof(int16_t);
-  int16_t output_value = static_cast<int16_t>(static_cast<float>(1 << 8) * value);
-
-  uint8_t data[8] = {0};
-  std::memcpy(data, &output_value, sizeof(int16_t));
-  std::copy(std::begin(data), std::end(data), std::begin(msg.data));
-
-  interface_->sendFrame(msg);
-}
-
-void Driver::sendFixed16x16(const uint32_t id, const double value)
-{
-  auto msg = getMsg(id);
-  msg.dlc = sizeof(int32_t);
-  int32_t output_value = static_cast<int32_t>(static_cast<double>((1 << 16) * value));
-
-  uint8_t data[8] = {0};
-  std::memcpy(data, &output_value, sizeof(int32_t));
-  std::copy(std::begin(data), std::end(data), std::begin(msg.data));
-
-  interface_->sendFrame(msg);
-}
-
-can_hardware::Frame Driver::getMsg(const uint32_t id)
-{
-  can_hardware::Frame msg;
-  msg.id = id;
-  msg.dlc = 0;
-  msg.is_extended = true;
-  return msg;
-}
-
-uint32_t Driver::getApi(const can_hardware::Frame & msg)
-{
-  return msg.id & (CAN_MSGID_FULL_M ^ CAN_MSGID_DEVNO_M);
-}
-
-uint32_t Driver::getDeviceNumber(const can_hardware::Frame & msg)
-{
-  return msg.id & CAN_MSGID_DEVNO_M;
-}
-
-bool Driver::verifyRaw16x16(const uint8_t * received, const double expected)
-{
-  uint8_t data[4];
-  int32_t output_value = static_cast<int32_t>(static_cast<double>((1 << 16) * expected));
-  std::memcpy(data, &output_value, 4);
-  for (uint8_t i = 0; i < 4; i++) {
-    if (*received != data[i]) {
-      return false;
-    }
-    received++;
-  }
-  return true;
-}
-
-bool Driver::verifyRaw8x8(const uint8_t * received, const float expected)
-{
-  uint8_t data[2];
-  int32_t output_value = static_cast<int32_t>(static_cast<float>((1 << 8) * expected));
-  std::memcpy(data, &output_value, 2);
-  for (uint8_t i = 0; i < 2; i++) {
-    if (*received != data[i]) {
-      return false;
-    }
-    received++;
-  }
-  return true;
 }
 
 void Driver::setEncoderCPR(const uint16_t encoder_cpr)
@@ -250,13 +179,13 @@ void Driver::setGearRatio(const float gear_ratio)
 
 void Driver::commandDutyCycle(const float cmd)
 {
-  sendFixed8x8((LM_API_VOLT_SET | device_number_), cmd);
+  // requestWrite(voltage_set_.name, cmd);
+  voltage_set_->requestWrite(cmd);
 }
 
 void Driver::commandSpeed(const double cmd)
 {
-  // Converting from rad/s to RPM through the gearbox.
-  sendFixed16x16((LM_API_SPD_SET | device_number_), (cmd * radPerSecToRpm()));
+  speed_set_->requestWrite(cmd * radPerSecToRpm());
 }
 
 void Driver::verifyParams()
@@ -267,7 +196,8 @@ void Driver::verifyParams()
       if (receivedPower()) {
         state_ = ConfigurationState::PowerFlag;
       } else {
-        sendId(LM_API_STATUS_POWER | device_number_);
+        // requestRead(status_power_.name);
+        status_power_->requestRead();
       }
       break;
     case ConfigurationState::PowerFlag:
@@ -279,7 +209,7 @@ void Driver::verifyParams()
           device_name_.c_str(), device_number_);
         state_ = ConfigurationState::EncoderPosRef;
       } else {
-        sendId(LM_API_STATUS_POWER | device_number_);
+        status_power_->requestRead();
       }
       break;
     case ConfigurationState::EncoderPosRef:
@@ -289,7 +219,7 @@ void Driver::verifyParams()
           "Puma Motor Controller on %s (%i): set position encoder reference.",
           device_name_.c_str(), device_number_);
       } else {
-        sendId(LM_API_POS_REF | device_number_);
+        position_ref_->requestRead();
       }
       break;
     case ConfigurationState::EncoderSpdRef:
@@ -299,7 +229,8 @@ void Driver::verifyParams()
           "Puma Motor Controller on %s (%i): set speed encoder reference.",
           device_name_.c_str(), device_number_);
       } else {
-        sendId(LM_API_SPD_REF | device_number_);
+        // requestRead(speed_ref_.name);
+        speed_ref_->requestRead();
       }
       break;
     case ConfigurationState::EncoderCounts:
@@ -309,7 +240,7 @@ void Driver::verifyParams()
           "Puma Motor Controller on %s (%i): set encoder counts to %i.",
           device_name_.c_str(), device_number_, encoder_cpr_);
       } else {
-        sendId(LM_API_CFG_ENC_LINES | device_number_);
+        cfg_enc_lines_->requestRead();
       }
       break;
     case ConfigurationState::ClosedLoop:  // Need to enter a close loop mode to record encoder data.
@@ -319,7 +250,10 @@ void Driver::verifyParams()
           "Puma Motor Controller on %s (%i): entered a close-loop control mode.",
           device_name_.c_str(), device_number_);
       } else {
-        sendId(LM_API_STATUS_CMODE | device_number_);
+        RCLCPP_WARN(rclcpp::get_logger("rclcpp"), 
+          "Puma Motor Controller on %s (%i): must be set to a close-loop control mode to configure parameters.",
+          device_name_.c_str(), device_number_);
+        status_control_mode_->requestRead();
       }
       break;
     case ConfigurationState::ControlMode:
@@ -338,7 +272,7 @@ void Driver::verifyParams()
       }
       break;
     case ConfigurationState::PGain:
-      if (verifyRaw16x16(getRawP(), gain_p_)) {
+      if (verify(getRawP(), gain_p_)) {
         state_ = ConfigurationState::IGain;
         RCLCPP_INFO(rclcpp::get_logger("rclcpp"),
           "Puma Motor Controller on %s (%i): P gain constant was set to %f and %f was requested.",
@@ -349,19 +283,19 @@ void Driver::verifyParams()
           device_name_.c_str(), device_number_, getP(), gain_p_);
         switch (control_mode_) {
           case clearpath_motor_msgs::msg::PumaStatus::MODE_CURRENT:
-            sendId(LM_API_ICTRL_PC | device_number_);
+            ictrl_pc_->requestRead();
             break;
           case clearpath_motor_msgs::msg::PumaStatus::MODE_POSITION:
-            sendId(LM_API_POS_PC | device_number_);
+            position_pc_->requestRead();
             break;
           case clearpath_motor_msgs::msg::PumaStatus::MODE_SPEED:
-            sendId(LM_API_SPD_PC | device_number_);
+            speed_pc_->requestRead();
             break;
         }
       }
       break;
     case ConfigurationState::IGain:
-      if (verifyRaw16x16(getRawI(), gain_i_)) {
+      if (verify(getRawI(), gain_i_)) {
         state_ = ConfigurationState::DGain;
         RCLCPP_INFO(rclcpp::get_logger("rclcpp"),
           "Puma Motor Controller on %s (%i): I gain constant was set to %f and %f was requested.",
@@ -372,19 +306,19 @@ void Driver::verifyParams()
           device_name_.c_str(), device_number_, getI(), gain_i_);
         switch (control_mode_) {
           case clearpath_motor_msgs::msg::PumaStatus::MODE_CURRENT:
-            sendId(LM_API_ICTRL_IC | device_number_);
+            ictrl_ic_->requestRead();
             break;
           case clearpath_motor_msgs::msg::PumaStatus::MODE_POSITION:
-            sendId(LM_API_POS_IC | device_number_);
+            position_ic_->requestRead();
             break;
           case clearpath_motor_msgs::msg::PumaStatus::MODE_SPEED:
-            sendId(LM_API_SPD_IC | device_number_);
+            speed_ic_->requestRead();
             break;
         }
       }
       break;
     case ConfigurationState::DGain:
-      if (verifyRaw16x16(getRawD(), gain_d_)) {
+      if (verify(getRawD(), gain_d_)) {
         state_ = ConfigurationState::VerifiedParameters;
         RCLCPP_INFO(rclcpp::get_logger("rclcpp"),
           "Puma Motor Controller on %s (%i): D gain constant was set to %f and %f was requested.",
@@ -395,13 +329,13 @@ void Driver::verifyParams()
           device_name_.c_str(), device_number_, getD(), gain_d_);
         switch (control_mode_) {
           case clearpath_motor_msgs::msg::PumaStatus::MODE_CURRENT:
-            sendId(LM_API_ICTRL_DC | device_number_);
+            ictrl_dc_->requestRead();
             break;
           case clearpath_motor_msgs::msg::PumaStatus::MODE_POSITION:
-            sendId(LM_API_POS_DC | device_number_);
+            position_dc_->requestRead();
             break;
           case clearpath_motor_msgs::msg::PumaStatus::MODE_SPEED:
-            sendId(LM_API_SPD_DC | device_number_);
+            speed_dc_->requestRead();
             break;
         }
       }
@@ -418,6 +352,10 @@ void Driver::verifyParams()
 
 void Driver::configureParams()
 {
+  RCLCPP_INFO(rclcpp::get_logger("rclcpp"),
+    "Puma Motor Controller on %s (%i): configuring parameters.",
+    device_name_.c_str(), device_number_);
+
   const double now = nh_->get_clock()->now().seconds();
   switch (state_) {
     case ConfigurationState::Initializing:
@@ -427,37 +365,40 @@ void Driver::configureParams()
       if (lastPower() == 1) {
         // Send request every second
         if ((now - last_power_clear_ts_) > 1.0) {
-          sendUint8((LM_API_STATUS_POWER | device_number_), 1);
+          status_power_->requestWrite(static_cast<uint8_t>(1));
           last_power_clear_ts_ = now;
         }
       }
       break;
     case ConfigurationState::EncoderPosRef:
-      sendUint8((LM_API_POS_REF | device_number_), LM_REF_ENCODER);
+      position_ref_->requestWrite(static_cast<uint8_t>(LM_REF_ENCODER));
       break;
     case ConfigurationState::EncoderSpdRef:
-      sendUint8((LM_API_SPD_REF | device_number_), LM_REF_QUAD_ENCODER);
+      RCLCPP_INFO(rclcpp::get_logger("rclcpp"),
+        "Puma Motor Controller on %s (%i): setting speed encoder reference to %i.",
+        device_name_.c_str(), device_number_, LM_REF_QUAD_ENCODER);
+      speed_ref_->requestWrite(static_cast<uint8_t>(LM_REF_QUAD_ENCODER));
       break;
     case ConfigurationState::EncoderCounts:
       // Set encoder CPR
-      sendUint16((LM_API_CFG_ENC_LINES | device_number_), encoder_cpr_);
+      cfg_enc_lines_->requestWrite(encoder_cpr_);
       break;
     case ConfigurationState::ClosedLoop:  // Need to enter a close loop mode to record encoder data.
-      sendId(LM_API_SPD_EN | device_number_);
+      speed_enable_->requestRead();
       break;
     case ConfigurationState::ControlMode:
       switch (control_mode_) {
         case clearpath_motor_msgs::msg::PumaStatus::MODE_VOLTAGE:
-          sendId(LM_API_VOLT_EN | device_number_);
+          voltage_enable_->requestRead();
           break;
         case clearpath_motor_msgs::msg::PumaStatus::MODE_CURRENT:
-          sendId(LM_API_ICTRL_EN | device_number_);
+          ictrl_enable_->requestRead();
           break;
         case clearpath_motor_msgs::msg::PumaStatus::MODE_POSITION:
-          sendId(LM_API_POS_EN | device_number_);
+          position_enable_->requestRead();
           break;
         case clearpath_motor_msgs::msg::PumaStatus::MODE_SPEED:
-          sendId(LM_API_SPD_EN | device_number_);
+          speed_enable_->requestRead();
           break;
       }
       break;
@@ -465,13 +406,13 @@ void Driver::configureParams()
       // Set P
       switch (control_mode_) {
         case clearpath_motor_msgs::msg::PumaStatus::MODE_CURRENT:
-          sendFixed16x16((LM_API_ICTRL_PC | device_number_), gain_p_);
+          ictrl_pc_->requestWrite(gain_p_);
           break;
         case clearpath_motor_msgs::msg::PumaStatus::MODE_POSITION:
-          sendFixed16x16((LM_API_POS_PC | device_number_), gain_p_);
+          position_pc_->requestWrite(gain_p_);
           break;
         case clearpath_motor_msgs::msg::PumaStatus::MODE_SPEED:
-          sendFixed16x16((LM_API_SPD_PC | device_number_), gain_p_);
+          speed_pc_->requestWrite(gain_p_);
           break;
       }
       break;
@@ -479,13 +420,13 @@ void Driver::configureParams()
       // Set I
       switch (control_mode_) {
         case clearpath_motor_msgs::msg::PumaStatus::MODE_CURRENT:
-          sendFixed16x16((LM_API_ICTRL_IC | device_number_), gain_i_);
+          ictrl_ic_->requestWrite(gain_i_);
           break;
         case clearpath_motor_msgs::msg::PumaStatus::MODE_POSITION:
-          sendFixed16x16((LM_API_POS_IC | device_number_), gain_i_);
+          position_ic_->requestWrite(gain_i_);
           break;
         case clearpath_motor_msgs::msg::PumaStatus::MODE_SPEED:
-          sendFixed16x16((LM_API_SPD_IC | device_number_), gain_i_);
+          speed_ic_->requestWrite(gain_i_);
           break;
       }
       break;
@@ -493,13 +434,13 @@ void Driver::configureParams()
       // Set D
       switch (control_mode_) {
         case clearpath_motor_msgs::msg::PumaStatus::MODE_CURRENT:
-          sendFixed16x16((LM_API_ICTRL_DC | device_number_), gain_d_);
+          ictrl_dc_->requestWrite(gain_d_);
           break;
         case clearpath_motor_msgs::msg::PumaStatus::MODE_POSITION:
-          sendFixed16x16((LM_API_POS_DC | device_number_), gain_d_);
+          position_dc_->requestWrite(gain_d_);
           break;
         case clearpath_motor_msgs::msg::PumaStatus::MODE_SPEED:
-          sendFixed16x16((LM_API_SPD_DC | device_number_), gain_d_);
+          speed_dc_->requestWrite(gain_d_);
           break;
       }
       break;
@@ -561,71 +502,58 @@ void Driver::setMode(const uint8_t mode, const double p, const double i, const d
   }
 }
 
-void Driver::clearMsgCache()
-{
-  // Set it all to zero, which will in part clear
-  // the boolean flags to be false.
-  memset(voltage_fields_, 0, sizeof(voltage_fields_));
-  memset(spd_fields_, 0, sizeof(spd_fields_));
-  memset(vcomp_fields_, 0, sizeof(vcomp_fields_));
-  memset(pos_fields_, 0, sizeof(pos_fields_));
-  memset(ictrl_fields_, 0, sizeof(ictrl_fields_));
-  memset(status_fields_, 0, sizeof(status_fields_));
-  memset(cfg_fields_, 0, sizeof(cfg_fields_));
-}
-
 void Driver::requestStatusMessages()
 {
-  sendId(LM_API_STATUS_POWER | device_number_);
+  status_power_->requestRead();
 }
 
 void Driver::requestFeedbackMessages()
 {
-  sendId(LM_API_STATUS_VOLTOUT | device_number_);
-  sendId(LM_API_STATUS_CURRENT | device_number_);
-  sendId(LM_API_STATUS_POS | device_number_);
-  sendId(LM_API_STATUS_SPD | device_number_);
-  sendId(LM_API_SPD_SET | device_number_);
+  status_voltage_out_->requestRead();
+  status_current_->requestRead();
+  status_position_->requestRead();
+  status_speed_->requestRead();
+  speed_set_->requestRead();
 }
 void Driver::requestFeedbackDutyCycle()
 {
-  sendId(LM_API_STATUS_VOLTOUT | device_number_);
+  status_voltage_out_->requestRead();
 }
 
 void Driver::requestFeedbackCurrent()
 {
-  sendId(LM_API_STATUS_CURRENT | device_number_);
+  status_current_->requestRead();
 }
 
 void Driver::requestFeedbackPosition()
 {
-  sendId(LM_API_STATUS_POS | device_number_);
+  status_position_->requestRead();
 }
 
 void Driver::requestFeedbackSpeed()
 {
-  sendId(LM_API_STATUS_SPD | device_number_);
+  status_speed_->requestRead();
 }
 
 void Driver::requestFeedbackPowerState()
 {
-  sendId(LM_API_STATUS_POWER | device_number_);
+  status_power_->requestRead();
 }
 
 void Driver::requestFeedbackSetpoint()
 {
   switch (control_mode_) {
     case clearpath_motor_msgs::msg::PumaStatus::MODE_CURRENT:
-      sendId(LM_API_ICTRL_SET | device_number_);
+      ictrl_set_->requestRead();
       break;
     case clearpath_motor_msgs::msg::PumaStatus::MODE_POSITION:
-      sendId(LM_API_POS_SET | device_number_);
+      position_set_->requestRead();
       break;
     case clearpath_motor_msgs::msg::PumaStatus::MODE_SPEED:
-      sendId(LM_API_SPD_SET | device_number_);
+      speed_set_->requestRead();
       break;
     case clearpath_motor_msgs::msg::PumaStatus::MODE_VOLTAGE:
-      sendId(LM_API_VOLT_SET | device_number_);
+      voltage_set_->requestRead();
       break;
   }
 }
@@ -644,68 +572,57 @@ void Driver::updateGains()
 
 bool Driver::receivedDutyCycle()
 {
-  Field * field = statusFieldForMessage(getApi(getMsg(LM_API_STATUS_VOLTOUT)));
-  return field->received;
+  return status_voltage_out_->received();
 }
 
 bool Driver::receivedBusVoltage()
 {
-  Field * field = statusFieldForMessage(getApi(getMsg(LM_API_STATUS_VOLTBUS)));
-  return field->received;
+  return status_voltage_bus_->received();
 }
 
 bool Driver::receivedCurrent()
 {
-  Field * field = statusFieldForMessage(getApi(getMsg(LM_API_STATUS_CURRENT)));
-  return field->received;
+  return status_current_->received();
 }
 
 bool Driver::receivedPosition()
 {
-  Field * field = statusFieldForMessage(getApi(getMsg(LM_API_STATUS_POS)));
-  return field->received;
+  return status_position_->received();
 }
 
 bool Driver::receivedSpeed()
 {
-  Field * field = statusFieldForMessage(getApi(getMsg(LM_API_STATUS_SPD)));
-  return field->received;
+  return status_speed_->received();
 }
 
 bool Driver::receivedFault()
 {
-  Field * field = statusFieldForMessage(getApi(getMsg(LM_API_STATUS_FAULT)));
-  return field->received;
+  return status_fault_->received();
 }
 
 bool Driver::receivedPower()
 {
-  Field * field = statusFieldForMessage(getApi(getMsg(LM_API_STATUS_POWER)));
-  return field->received;
+  return status_power_->received();
 }
 
 bool Driver::receivedMode()
 {
-  Field * field = statusFieldForMessage(getApi(getMsg(LM_API_STATUS_CMODE)));
-  return field->received;
+  return status_control_mode_->received();
 }
 
 bool Driver::receivedOutVoltage()
 {
-  Field * field = statusFieldForMessage(getApi(getMsg(LM_API_STATUS_VOUT)));
-  return field->received;
+  return status_vout_->received();
 }
 
 bool Driver::receivedTemperature()
 {
-  Field * field = statusFieldForMessage(getApi(getMsg(LM_API_STATUS_TEMP)));
-  return field->received;
+  return status_temperature_->received();
 }
 
 bool Driver::receivedAnalogInput()
 {
-  Field * field = statusFieldForMessage(getApi(getMsg(CPR_API_STATUS_ANALOG)));
-  return field->received;
+  return status_analog_->received();
 }
 
 bool Driver::receivedSetpoint()
@@ -731,103 +648,77 @@ bool Driver::receivedSetpoint()
 
 bool Driver::receivedSpeedSetpoint()
 {
-  Field * field = spdFieldForMessage(getApi(getMsg(LM_API_SPD_SET)));
-  return field->received;
+  return speed_set_->received();
 }
 
 bool Driver::receivedDutyCycleSetpoint()
 {
-  Field * field = voltageFieldForMessage(getApi(getMsg(LM_API_VOLT_SET)));
-  return field->received;
+  return voltage_set_->received();
 }
 
 bool Driver::receivedCurrentSetpoint()
 {
-  Field * field = ictrlFieldForMessage(getApi(getMsg(LM_API_ICTRL_SET)));
-  return field->received;
+  return ictrl_set_->received();
 }
 
 bool Driver::receivedPositionSetpoint()
 {
-  Field * field = posFieldForMessage(getApi(getMsg(LM_API_POS_SET)));
-  return field->received;
+  return position_set_->received();
 }
 
 float Driver::lastDutyCycle()
 {
-  Field * field = statusFieldForMessage(getApi(getMsg(LM_API_STATUS_VOLTOUT)));
-  field->received = false;
-  return field->interpretFixed8x8() / 128.0;
+  return status_voltage_out_->value() / 128.0;
 }
 
 float Driver::lastBusVoltage()
 {
-  Field * field = statusFieldForMessage(getApi(getMsg(LM_API_STATUS_VOLTBUS)));
-  field->received = false;
-  return field->interpretFixed8x8();
+  return status_voltage_bus_->value();
 }
 
 float Driver::lastCurrent()
 {
-  Field * field = statusFieldForMessage(getApi(getMsg(LM_API_STATUS_CURRENT)));
-  field->received = false;
-  return field->interpretFixed8x8();
+  return status_current_->value();
 }
 
 double Driver::lastPosition()
 {
-  Field * field = statusFieldForMessage(getApi(getMsg(LM_API_STATUS_POS)));
-  field->received = false;
-  return field->interpretFixed16x16() * ((2 * M_PI) / gear_ratio_);  // Convert rev to rad
+  return status_position_->value() * ((2 * M_PI) / gear_ratio_);  // Convert rev to rad
 }
 
 double Driver::lastSpeed()
 {
-  Field * field = statusFieldForMessage(getApi(getMsg(LM_API_STATUS_SPD)));
-  field->received = false;
-  return field->interpretFixed16x16() * ((2 * M_PI) / (gear_ratio_ * 60));  // Convert RPM to rad/s
+  return status_speed_->value() * ((2 * M_PI) / (gear_ratio_ * 60));  // Convert RPM to rad/s
 }
 
 uint8_t Driver::lastFault()
 {
-  Field * field = statusFieldForMessage(getApi(getMsg(LM_API_STATUS_FAULT)));
-  field->received = false;
-  return field->data[0];
+  return status_fault_->value();
 }
 
 uint8_t Driver::lastPower()
 {
-  Field * field = statusFieldForMessage(getApi(getMsg(LM_API_STATUS_POWER)));
-  field->received = false;
-  return field->data[0];
+  return status_power_->value();
 }
 
 uint8_t Driver::lastMode()
 {
-  Field * field = statusFieldForMessage(getApi(getMsg(LM_API_STATUS_CMODE)));
-  field->received = false;
-  return field->data[0];
+  return status_control_mode_->value();
 }
 
 float Driver::lastOutVoltage()
 {
-  Field * field = statusFieldForMessage(getApi(getMsg(LM_API_STATUS_VOUT)));
-  field->received = false;
-  return field->interpretFixed8x8();
+  return status_vout_->value();
 }
 
 float Driver::lastTemperature()
 {
-  Field * field = statusFieldForMessage(getApi(getMsg(LM_API_STATUS_TEMP)));
-  field->received = false;
-  return field->interpretFixed8x8();
+  return status_temperature_->value();
 }
 
 float Driver::lastAnalogInput()
 {
-  Field * field = statusFieldForMessage(getApi(getMsg(CPR_API_STATUS_ANALOG)));
-  field->received = false;
-  return field->interpretFixed8x8();
+  return status_analog_->value();
 }
 
 double Driver::lastSetpoint()
@@ -852,192 +743,94 @@ double Driver::lastSetpoint()
 }
 double Driver::statusSpeedGet()
 {
-  Field * field = spdFieldForMessage(getApi(getMsg(LM_API_SPD_SET)));
-  field->received = false;
-  return field->interpretFixed16x16() * ((2 * M_PI) / (gear_ratio_ * 60));  // Convert RPM to rad/s
+  return status_speed_->value() * ((2 * M_PI) / (gear_ratio_ * 60));  // Convert RPM to rad/s
 }
 
 float Driver::statusDutyCycleGet()
 {
-  Field * field = voltageFieldForMessage(getApi(getMsg(LM_API_VOLT_SET)));
-  field->received = false;
-  return field->interpretFixed8x8() / 128.0;
+  return voltage_set_->value() / 128.0;
 }
 
 float Driver::statusCurrentGet()
 {
-  Field * field = ictrlFieldForMessage(getApi(getMsg(LM_API_ICTRL_SET)));
-  field->received = false;
-  return field->interpretFixed8x8();
+  return ictrl_set_->value();
 }
 
 double Driver::statusPositionGet()
 {
-  Field * field = posFieldForMessage(getApi(getMsg(LM_API_POS_SET)));
-  field->received = false;
-  return field->interpretFixed16x16() * (( 2 * M_PI) / gear_ratio_);  // Convert rev to rad
+  return position_set_->value() * (( 2 * M_PI) / gear_ratio_);  // Convert rev to rad
 }
 
 uint8_t Driver::posEncoderRef()
 {
-  Field * field = posFieldForMessage(getApi(getMsg(LM_API_POS_REF)));
-  return field->data[0];
+  return position_ref_->value();
 }
 
 uint8_t Driver::spdEncoderRef()
 {
-  Field * field = spdFieldForMessage(getApi(getMsg(LM_API_SPD_REF)));
-  return field->data[0];
+  return speed_ref_->value();
 }
 
 uint16_t Driver::encoderCounts()
 {
-  Field * field = cfgFieldForMessage(getApi(getMsg(LM_API_CFG_ENC_LINES)));
-  return static_cast<uint16_t>(field->data[0]) | static_cast<uint16_t>(field->data[1] << 8);
+  return cfg_enc_lines_->value();
 }
 
 double Driver::getP()
 {
-  Field * field = nullptr;
-  switch (control_mode_) {
-    case clearpath_motor_msgs::msg::PumaStatus::MODE_CURRENT:
-      field = ictrlFieldForMessage(getApi(getMsg(LM_API_ICTRL_PC)));
-      break;
-    case clearpath_motor_msgs::msg::PumaStatus::MODE_POSITION:
-      field = posFieldForMessage(getApi(getMsg(LM_API_POS_PC)));
-      break;
-    case clearpath_motor_msgs::msg::PumaStatus::MODE_SPEED:
-      field = spdFieldForMessage(getApi(getMsg(LM_API_SPD_PC)));
-      break;
-  }
-  return field->interpretFixed16x16();
+  return getRawP();
 }
 
 double Driver::getI()
 {
-  Field * field = nullptr;
-  switch (control_mode_) {
-    case clearpath_motor_msgs::msg::PumaStatus::MODE_CURRENT:
-      field = ictrlFieldForMessage(getApi(getMsg(LM_API_ICTRL_IC)));
-      break;
-    case clearpath_motor_msgs::msg::PumaStatus::MODE_POSITION:
-      field = posFieldForMessage(getApi(getMsg(LM_API_POS_IC)));
-      break;
-    case clearpath_motor_msgs::msg::PumaStatus::MODE_SPEED:
-      field = spdFieldForMessage(getApi(getMsg(LM_API_SPD_IC)));
-      break;
-  }
-  return field->interpretFixed16x16();
+  return getRawI();
 }
 
 double Driver::getD()
 {
-  Field * field = nullptr;
+  return getRawD();
+}
+
+double Driver::getRawP()
+{
   switch (control_mode_) {
     case clearpath_motor_msgs::msg::PumaStatus::MODE_CURRENT:
-      field = ictrlFieldForMessage(getApi(getMsg(LM_API_ICTRL_DC)));
-      break;
+      return ictrl_pc_->value();
     case clearpath_motor_msgs::msg::PumaStatus::MODE_POSITION:
-      field = posFieldForMessage(getApi(getMsg(LM_API_POS_DC)));
-      break;
+      return position_pc_->value();
     case clearpath_motor_msgs::msg::PumaStatus::MODE_SPEED:
-      field = spdFieldForMessage(getApi(getMsg(LM_API_SPD_DC)));
-      break;
+      return speed_pc_->value();
+    default:
+      return 0.0;
   }
-  return field->interpretFixed16x16();
 }
 
-uint8_t * Driver::getRawP()
+double Driver::getRawI()
 {
-  Field * field = nullptr;
   switch (control_mode_) {
     case clearpath_motor_msgs::msg::PumaStatus::MODE_CURRENT:
-      field = ictrlFieldForMessage(getApi(getMsg(LM_API_ICTRL_PC)));
-      break;
+      return ictrl_ic_->value();
     case clearpath_motor_msgs::msg::PumaStatus::MODE_POSITION:
-      field = posFieldForMessage(getApi(getMsg(LM_API_POS_PC)));
-      break;
+      return position_ic_->value();
     case clearpath_motor_msgs::msg::PumaStatus::MODE_SPEED:
-      field = spdFieldForMessage(getApi(getMsg(LM_API_SPD_PC)));
-      break;
+      return speed_ic_->value();
+    default:
+      return 0.0;
   }
-  return field->data;
 }
 
-uint8_t * Driver::getRawI()
+double Driver::getRawD()
 {
-  Field * field = nullptr;
   switch (control_mode_) {
     case clearpath_motor_msgs::msg::PumaStatus::MODE_CURRENT:
-      field = ictrlFieldForMessage(getApi(getMsg(LM_API_ICTRL_IC)));
-      break;
+      return ictrl_dc_->value();
     case clearpath_motor_msgs::msg::PumaStatus::MODE_POSITION:
-      field = posFieldForMessage(getApi(getMsg(LM_API_POS_IC)));
-      break;
+      return position_dc_->value();
     case clearpath_motor_msgs::msg::PumaStatus::MODE_SPEED:
-      field = spdFieldForMessage(getApi(getMsg(LM_API_SPD_IC)));
-      break;
+      return speed_dc_->value();
+    default:
+      return 0.0;
   }
-  return field->data;
-}
-
-uint8_t * Driver::getRawD()
-{
-  Field * field = nullptr;
-  switch (control_mode_) {
-    case clearpath_motor_msgs::msg::PumaStatus::MODE_CURRENT:
-      field = ictrlFieldForMessage(getApi(getMsg(LM_API_ICTRL_DC)));
-      break;
-    case clearpath_motor_msgs::msg::PumaStatus::MODE_POSITION:
-      field = posFieldForMessage(getApi(getMsg(LM_API_POS_DC)));
-      break;
-    case clearpath_motor_msgs::msg::PumaStatus::MODE_SPEED:
-      field = spdFieldForMessage(getApi(getMsg(LM_API_SPD_DC)));
-      break;
-  }
-  return field->data;
-}
-
-Driver::Field * Driver::voltageFieldForMessage(uint32_t api)
-{
-  uint32_t voltage_field_index = (api & CAN_MSGID_API_ID_M) >> CAN_MSGID_API_S;
-  return &voltage_fields_[voltage_field_index];
-}
-
-Driver::Field * Driver::spdFieldForMessage(uint32_t api)
-{
-  uint32_t spd_field_index = (api & CAN_MSGID_API_ID_M) >> CAN_MSGID_API_S;
-  return &spd_fields_[spd_field_index];
-}
-
-Driver::Field * Driver::vcompFieldForMessage(uint32_t api)
-{
-  uint32_t vcomp_field_index = (api & CAN_MSGID_API_ID_M) >> CAN_MSGID_API_S;
-  return &vcomp_fields_[vcomp_field_index];
-}
-
-Driver::Field * Driver::posFieldForMessage(uint32_t api)
-{
-  uint32_t pos_field_index = (api & CAN_MSGID_API_ID_M) >> CAN_MSGID_API_S;
-  return &pos_fields_[pos_field_index];
-}
-
-Driver::Field * Driver::ictrlFieldForMessage(uint32_t api)
-{
-  uint32_t ictrl_field_index = (api & CAN_MSGID_API_ID_M) >> CAN_MSGID_API_S;
-  return &ictrl_fields_[ictrl_field_index];
-}
-
-Driver::Field * Driver::statusFieldForMessage(uint32_t api)
-{
-  uint32_t status_field_index = (api & CAN_MSGID_API_ID_M) >> CAN_MSGID_API_S;
-  return &status_fields_[status_field_index];
-}
-
-Driver::Field * Driver::cfgFieldForMessage(uint32_t api)
-{
-  uint32_t cfg_field_index = (api & CAN_MSGID_API_ID_M) >> CAN_MSGID_API_S;
-  return &cfg_fields_[cfg_field_index];
 }
 
 /**

--- a/clearpath_motor_drivers/puma_motor_driver/src/multi_puma_node.cpp
+++ b/clearpath_motor_drivers/puma_motor_driver/src/multi_puma_node.cpp
@@ -94,13 +94,11 @@ MultiPumaNode::MultiPumaNode(const std::string node_name)
   node_handle_ = std::shared_ptr<rclcpp::Node>(this, [](rclcpp::Node *){});
 
   // SocketCAN Interface
-  interface_ = std::make_shared<can_hardware::drivers::SocketCanDriver>(canbus_dev_);
-  interface_->registerFrameCallback(
-    std::bind(&MultiPumaNode::frameCallback, this,  std::placeholders::_1));
+  interface_ = std::make_unique<CanConnection>(canbus_dev_);
 
   for (uint8_t i = 0; i < joint_names_.size(); i++) {
-    drivers_.push_back(puma_motor_driver::Driver(
-      interface_,
+    drivers_.emplace_back(std::make_unique<puma_motor_driver::Driver>(
+      interface_.get(),
       node_handle_,
       joint_can_ids_[i],
       joint_names_[i]
@@ -112,10 +110,9 @@ MultiPumaNode::MultiPumaNode(const std::string node_name)
 
   uint8_t i = 0;
   for (auto & driver : drivers_) {
-    driver.clearMsgCache();
-    driver.setEncoderCPR(encoder_cpr_);
-    driver.setGearRatio(gear_ratio_ * joint_directions_[i]);
-    driver.setMode(desired_mode_, gain_p_, gain_i_, gain_d_);
+    driver->setEncoderCPR(encoder_cpr_);
+    driver->setGearRatio(gear_ratio_ * joint_directions_[i]);
+    driver->setMode(desired_mode_, gain_p_, gain_i_, gain_d_);
     i++;
   }
 
@@ -135,11 +132,11 @@ bool MultiPumaNode::getFeedback()
   // Check All Fields Received
   uint8_t received = 0;
   for (auto & driver : drivers_) {
-    received |= driver.receivedDutyCycle() << FeedbackBit::DutyCycle;
-    received |= driver.receivedCurrent() << FeedbackBit::Current;
-    received |= driver.receivedPosition() << FeedbackBit::Position;
-    received |= driver.receivedSpeed() << FeedbackBit::Speed;
-    received |= driver.receivedSetpoint() << FeedbackBit::Setpoint;
+    received |= driver->receivedDutyCycle() << FeedbackBit::DutyCycle;
+    received |= driver->receivedCurrent() << FeedbackBit::Current;
+    received |= driver->receivedPosition() << FeedbackBit::Position;
+    received |= driver->receivedSpeed() << FeedbackBit::Speed;
+    received |= driver->receivedSetpoint() << FeedbackBit::Setpoint;
   }
 
   if (received != (1 << FeedbackBit::Count) - 1) {
@@ -149,13 +146,13 @@ bool MultiPumaNode::getFeedback()
   uint8_t feedback_index = 0;
   for (auto & driver : drivers_) {
     clearpath_motor_msgs::msg::PumaFeedback * f = &feedback_msg_.drivers_feedback[feedback_index];
-    f->device_number = driver.deviceNumber();
-    f->device_name = driver.deviceName();
-    f->duty_cycle = driver.lastDutyCycle();
-    f->current = driver.lastCurrent();
-    f->travel = driver.lastPosition();
-    f->speed = driver.lastSpeed();
-    f->setpoint = driver.lastSetpoint();
+    f->device_number = driver->deviceNumber();
+    f->device_name = driver->deviceName();
+    f->duty_cycle = driver->lastDutyCycle();
+    f->current = driver->lastCurrent();
+    f->travel = driver->lastPosition();
+    f->speed = driver->lastSpeed();
+    f->setpoint = driver->lastSetpoint();
 
     feedback_index++;
   }
@@ -170,13 +167,13 @@ bool MultiPumaNode::getStatus()
   uint8_t received_fields = 0;
   uint8_t received_status = 0;
   for (auto & driver : drivers_) {
-    received_fields |= driver.receivedBusVoltage() << StatusBit::BusVoltage;
-    received_fields |= driver.receivedOutVoltage() << StatusBit::OutVoltage;
-    received_fields |= driver.receivedAnalogInput() << StatusBit::AnalogInput;
+    received_fields |= driver->receivedBusVoltage() << StatusBit::BusVoltage;
+    received_fields |= driver->receivedOutVoltage() << StatusBit::OutVoltage;
+    received_fields |= driver->receivedAnalogInput() << StatusBit::AnalogInput;
     received_fields |= 1 << StatusBit::AnalogInput;
-    received_fields |= driver.receivedTemperature() << StatusBit::Temperature;
-    received_fields |= driver.receivedMode() << StatusBit::Mode;
-    received_fields |= driver.receivedFault() << StatusBit::Fault;
+    received_fields |= driver->receivedTemperature() << StatusBit::Temperature;
+    received_fields |= driver->receivedMode() << StatusBit::Mode;
+    received_fields |= driver->receivedFault() << StatusBit::Fault;
     if (received_fields != (1 << StatusBit::Count) - 1) {
       RCLCPP_DEBUG(this->get_logger(), "Received Status Fields %x", received_fields);
     } else {
@@ -194,14 +191,14 @@ bool MultiPumaNode::getStatus()
   status_index = 0;
   for (auto & driver : drivers_) {
     clearpath_motor_msgs::msg::PumaStatus * s = &status_msg_.drivers[status_index];
-    s->device_number = driver.deviceNumber();
-    s->device_name = driver.deviceName();
-    s->bus_voltage = driver.lastBusVoltage();
-    s->output_voltage = driver.lastOutVoltage();
-    s->analog_input = driver.lastAnalogInput();
-    s->temperature = driver.lastTemperature();
-    s->mode = driver.lastMode();
-    s->fault = driver.lastFault();
+    s->device_number = driver->deviceNumber();
+    s->device_name = driver->deviceName();
+    s->bus_voltage = driver->lastBusVoltage();
+    s->output_voltage = driver->lastOutVoltage();
+    s->analog_input = driver->lastAnalogInput();
+    s->temperature = driver->lastTemperature();
+    s->mode = driver->lastMode();
+    s->fault = driver->lastFault();
 
     status_index++;
   }
@@ -233,7 +230,7 @@ void MultiPumaNode::driverDiagnostic(DiagnosticStatusWrapper & stat, int i)
   // Assume we're OK. This will be merged over later on if we aren't
   stat.summary(DiagnosticStatusWrapper::OK, "OK");
 
-  drivers_[i].runFreqStatus(stat);
+  drivers_[i]->runFreqStatus(stat);
 
   // basic stats
   stat.add("CAN ID", (int)status_msg_.drivers[i].device_number);
@@ -262,11 +259,11 @@ void MultiPumaNode::cmdCallback(const sensor_msgs::msg::JointState::SharedPtr ms
   if (active_) {
     for (auto & driver : drivers_) {
       for (int i = 0; i < static_cast<int>(msg->name.size()); i++) {
-        if (driver.deviceName() == msg->name[i]) {
+        if (driver->deviceName() == msg->name[i]) {
           if (desired_mode_ == clearpath_motor_msgs::msg::PumaStatus::MODE_VOLTAGE) {
-            driver.commandDutyCycle(msg->velocity[i]);
+            driver->commandDutyCycle(msg->velocity[i]);
           } else if (desired_mode_ == clearpath_motor_msgs::msg::PumaStatus::MODE_SPEED) {
-            driver.commandSpeed(msg->velocity[i]);
+            driver->commandSpeed(msg->velocity[i]);
           }
         }
       }
@@ -277,62 +274,56 @@ void MultiPumaNode::cmdCallback(const sensor_msgs::msg::JointState::SharedPtr ms
 bool MultiPumaNode::areAllActive()
 {
   for (auto & driver : drivers_) {
-    if (!driver.isConfigured()) {
+    if (!driver->isConfigured()) {
       return false;
     }
   }
   return true;
 }
 
-void MultiPumaNode::frameCallback(const can_hardware::Frame& frame)
-{
-  std::lock_guard<std::mutex> lock(recv_msg_mutex_);
-  recv_msg_queue_.push(frame);
-}
-
 void MultiPumaNode::run()
 {
+  RCLCPP_INFO_THROTTLE(this->get_logger(), *this->get_clock(), 5000,
+    "[HAL-y Code]: MultiPumaNode Run Cycle %d", status_count_);
+
   if (active_) {
     // Checks to see if power flag has been reset for each driver
     for (auto & driver : drivers_) {
-      if (driver.lastPower() != 0) {
+      if (driver->lastPower() != 0) {
         active_ = false;
         RCLCPP_WARN(this->get_logger(),
           "Power reset detected on device ID %d, will reconfigure all drivers.",
-          driver.deviceNumber());
+          driver->deviceNumber());
         for (auto & driver : drivers_) {
-          driver.resetConfiguration();
+          driver->resetConfiguration();
         }
       }
     }
     // Queue data requests for the drivers in order to assemble an amalgamated status message.
     for (auto & driver : drivers_) {
-      driver.requestStatusMessages();
-      driver.requestFeedbackSetpoint();
+      driver->requestStatusMessages();
+      driver->requestFeedbackSetpoint();
     }
   } else {
-    // Set parameters for each driver.
+    // Set parameters for each driver->
     for (auto & driver : drivers_) {
-      driver.configureParams();
+      driver->configureParams();
     }
   }
 
-  while (!recv_msg_queue_.empty()) {
-    can_hardware::Frame frame;
-    {
-      std::lock_guard<std::mutex> lock(recv_msg_mutex_);
-      frame = std::move(recv_msg_queue_.front());
-      recv_msg_queue_.pop();
-    }
-    for (auto & driver : drivers_) {
-      driver.processMessage(frame);
-    }
+  const auto now = this->get_clock()->now();
+
+  for (auto & driver : drivers_) {
+    // Update for HAL signals
+    driver->write(now);
   }
 
   // Check parameters of each driver instance.
   if (!active_) {
     for (auto & driver : drivers_) {
-      driver.verifyParams();
+      RCLCPP_INFO_THROTTLE(this->get_logger(), *this->get_clock(), 1000,
+        "Verifying parameters for device ID %d", driver->deviceNumber());
+      driver->verifyParams();
     }
   }
 


### PR DESCRIPTION
This PR implements the puma motor drivers using HAL CAN adaptors.

In the context of the puma drivers the `Driver` class is a HAL `SignalAdaptor` responsible for mapping signals to and from the device. The `MultiPumaNode` is just initialising 4 adaptors.

**HAL Concepts**

HAL supports cyclic and acyclic data. That is: streaming data, and data on request.

The implementation of this varies between protocols. For CAN this uses RTR frames.

**Puma Concepts** 

The puma driver statemachine is effectively: configure, verify, run.

out of the box the CAN adaptor doesn't support this, so we can't move to pure configs just yet.

The protocol used by the pumas as a request data mechanism similar to RTR frame (though it doesn't set the RTR flag).

**Changes**

First off all the signal registration now happens upfront (CAN IDs and data type). previously you'd have to look at where the CAN IDs were used to understand the data types.

Part of the fixed point float conversion is now managed automatically by the adaptor.

Support was added in the CAN adaptor to override the request read frames. In the context the pumas, this is clearing the RTR flag.

A puma specific signal type was added to wrap the adaptor and add better semantics around interacting with the signals. This is a feature I'd like to add to the core eventually.

**Future work**

Generalisation of the state machine can be done to enable implementation without bespoke code.

Once ros2_control support is added to hal we can map signals to joints from the urdf.