### PR TITLE
Fix: Robot Install

### DIFF
--- a/clearpath_robot/scripts/install
+++ b/clearpath_robot/scripts/install
@@ -364,7 +364,7 @@ robot.install(Provider=RobotProvider)
 # Platform
 platform = robot_upstart.Job(
     name='clearpath-platform',
-    user=config.system.username,
+    user=clearpath_config.system.username,
     rmw=rmw,
     workspace_setup=workspace_setup,
     ros_domain_id=domain_id)
@@ -379,7 +379,7 @@ platform_provider_files.install(Provider=PlatformProvider)
 # Platform extras
 platform_extras = robot_upstart.Job(
     name='clearpath-platform-extras',
-    user=config.system.username,
+    user=clearpath_config.system.username,
     rmw=rmw,
     workspace_setup=workspace_setup,
     ros_domain_id=domain_id)
@@ -394,7 +394,7 @@ platform_extras_provider_files.install(Provider=PlatformExtrasProvider)
 # Sensors
 sensors = robot_upstart.Job(
     name='clearpath-sensors',
-    user=config.system.username,
+    user=clearpath_config.system.username,
     rmw=rmw,
     workspace_setup=workspace_setup,
     ros_domain_id=domain_id)
@@ -409,7 +409,7 @@ sensors_provider_files.install(Provider=SensorsProvider)
 # Manipulators
 manipulators = robot_upstart.Job(
     name='clearpath-manipulators',
-    user=config.system.username,
+    user=clearpath_config.system.username,
     rmw=rmw,
     workspace_setup=workspace_setup,
     ros_domain_id=domain_id)

--- a/clearpath_robot/scripts/install
+++ b/clearpath_robot/scripts/install
@@ -364,6 +364,7 @@ robot.install(Provider=RobotProvider)
 # Platform
 platform = robot_upstart.Job(
     name='clearpath-platform',
+    user=config.system.username,
     rmw=rmw,
     workspace_setup=workspace_setup,
     ros_domain_id=domain_id)
@@ -378,6 +379,7 @@ platform_provider_files.install(Provider=PlatformProvider)
 # Platform extras
 platform_extras = robot_upstart.Job(
     name='clearpath-platform-extras',
+    user=config.system.username,
     rmw=rmw,
     workspace_setup=workspace_setup,
     ros_domain_id=domain_id)
@@ -392,6 +394,7 @@ platform_extras_provider_files.install(Provider=PlatformExtrasProvider)
 # Sensors
 sensors = robot_upstart.Job(
     name='clearpath-sensors',
+    user=config.system.username,
     rmw=rmw,
     workspace_setup=workspace_setup,
     ros_domain_id=domain_id)
@@ -406,6 +409,7 @@ sensors_provider_files.install(Provider=SensorsProvider)
 # Manipulators
 manipulators = robot_upstart.Job(
     name='clearpath-manipulators',
+    user=config.system.username,
     rmw=rmw,
     workspace_setup=workspace_setup,
     ros_domain_id=domain_id)


### PR DESCRIPTION
Pass in the `user` parameter to ensure that the `ROS_HOME` is set in the `/usr/sbin/clearpath-{JOBNAME}-start` script. 