### PR TITLE
Fix: CMake Verision and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,9 @@ on:
 jobs:
   clearpath_robot_cpr_ci:
     name: Jazzy Clearpath Release
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
+    container:
+      image: ubuntu:noble
     steps:
       - uses: actions/checkout@v3
       - uses: ros-tooling/setup-ros@v0.7
@@ -33,7 +35,9 @@ jobs:
             clearpath_sensors
   clearpath_robot_src_ci:
     name: Jazzy Clearpath Source
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
+    container:
+      image: ubuntu:noble
     steps:
       - uses: actions/checkout@v3
       - uses: ros-tooling/setup-ros@v0.7
@@ -58,7 +62,9 @@ jobs:
           vcs-repo-file-url: dependencies.repos
   clearpath_robot_src_head_ci:
     name: Jazzy Clearpath Source with Head Branch
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
+    container:
+      image: ubuntu:noble
     steps:
       - uses: actions/checkout@v3
       - uses: actions/checkout@v3
@@ -102,7 +108,9 @@ jobs:
   clearpath_robot_src_base_ci:
     if: github.event_name == 'pull_request'
     name: Jazzy Clearpath Source with Base Branch
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
+    container:
+      image: ubuntu:noble
     steps:
       - uses: actions/checkout@v3
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           repository: clearpathrobotics/repos-dep-update-action
-          ref: 0.0.1
+          ref: 0.0.3
           path: repos-dep-update-action
       - name: Extract branch name
         shell: bash
@@ -116,7 +116,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           repository: clearpathrobotics/repos-dep-update-action
-          ref: 0.0.1
+          ref: 0.0.3
           path: repos-dep-update-action
       - name: Use repos update action
         uses: ./repos-dep-update-action/

--- a/clearpath_generator_robot/CMakeLists.txt
+++ b/clearpath_generator_robot/CMakeLists.txt
@@ -37,7 +37,7 @@ if(BUILD_TESTING)
     get_filename_component(_test_name ${_test_path} NAME_WE)
     ament_add_pytest_test(${_test_name} ${_test_path}
       APPEND_ENV PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}
-      TIMEOUT 60
+      TIMEOUT 180
       WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
     )
   endforeach()

--- a/clearpath_generator_robot/CMakeLists.txt
+++ b/clearpath_generator_robot/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.20)
 project(clearpath_generator_robot)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")

--- a/clearpath_hardware_interfaces/CMakeLists.txt
+++ b/clearpath_hardware_interfaces/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.20)
 project(clearpath_hardware_interfaces)
 
 # Default to C++14

--- a/clearpath_motor_drivers/lynx_motor_driver/CMakeLists.txt
+++ b/clearpath_motor_drivers/lynx_motor_driver/CMakeLists.txt
@@ -1,7 +1,7 @@
 ################################################################################
 # Set minimum required version of cmake, project name and compile options
 ################################################################################
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.20)
 project(lynx_motor_driver)
 
 if (NOT CMAKE_CXX_STANDARD)

--- a/clearpath_motor_drivers/puma_motor_driver/CMakeLists.txt
+++ b/clearpath_motor_drivers/puma_motor_driver/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.20)
 project(puma_motor_driver)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")

--- a/clearpath_robot/CMakeLists.txt
+++ b/clearpath_robot/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.20)
 project(clearpath_robot)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")

--- a/clearpath_sensors/CMakeLists.txt
+++ b/clearpath_sensors/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.20)
 project(clearpath_sensors)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")


### PR DESCRIPTION
Update the cmake version to 3.20 to avoid deprecation warning. 

Switch action from running on GitHub runner image and instead run in container. 