### PR TITLE
Ensures the robot service waits for clock synchronization before star…

### DIFF
--- a/clearpath_robot/services/clearpath-robot.service
+++ b/clearpath_robot/services/clearpath-robot.service
@@ -1,6 +1,8 @@
 [Unit]
 Description="Clearpath robot main generation and bringup service"
 After=network-online.target
+Wants=systemd-time-wait-sync.service
+After=systemd-time-wait-sync.service
 
 [Service]
 User=robot


### PR DESCRIPTION
…ting.  This was due to Zenoh rejecting messages due to timestamps being out of sync.