### PR TITLE
Feature: Add Support for Hesai Lidar

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -11,7 +11,8 @@
     "**/meshes/**",
     "**/*.dae",
     "**/*.stl",
-    "**/*.STL"
+    "**/*.STL",
+    "**/config/hesai_config.yaml"
   ],
   "import": [
     "@cspell/dict-en-ca/cspell-ext.json"

--- a/clearpath_sensors/config/hesai_config.yaml
+++ b/clearpath_sensors/config/hesai_config.yaml
@@ -1,0 +1,92 @@
+lidar:
+  - driver:
+      use_gpu: false
+      source_type: 1                                  # The type of data source, 1: real-time lidar connection, 2: pcap, 3: packet rosbag, 4: serial
+      # Depending on the type of source_type, fill in the corresponding configuration block (lidar_udp_type, pcap_type, serial_type)
+      lidar_udp_type:
+        device_ip_address: 192.168.131.25             # host_ip_address. If empty(""), the source ip of the udp point cloud is used
+        udp_port: 2368                                # UDP destination port
+        ptc_port: 9347                                # PTC port of lidar
+        multicast_ip_address: 192.168.131.1           # IP for the robot
+
+        use_ptc_connected: true                       # Set to false when ptc connection is not used
+        host_ptc_port: 0                              # PTC source port, 0 means auto
+        correction_file_path: "Your correction file path"   # The path of correction file
+        firetimes_path: "Your firetime file path"           # The path of firetimes file
+
+        recv_point_cloud_timeout: -1                  # The timeout of receiving point cloud
+        ptc_connect_timeout: -1                       # The timeout of ptc connection
+
+        host_ip_address: ""
+        fault_message_port: 0
+
+        standby_mode: -1                              # The standby mode: [-1] is invalit [0] in operation [1] standby
+        speed: -1                                     # The speed: [-1] invalit, you must make sure your set has been supported by the lidar you are using
+        ptc_mode: 0                                   # The ptc mode: [0] tcp [1] tcp_ssl
+        # tcp_ssl use
+        certFile: ""                                  # Represents the path of the user's certificate
+        privateKeyFile: ""                            # Represents the path of the user's private key
+        caFile: ""                                    # Represents the path of the CA certificate
+
+      pcap_type:
+        pcap_path: "Your pcap file"                         # The path of pcap file
+        correction_file_path: "Your correction file path"   # The path of correction file
+        firetimes_path: "Your firetime file path"           # The path of firetimes file
+
+        pcap_play_synchronization: true                     # pcap play rate synchronize with the host time
+        pcap_play_in_loop: false
+        play_rate_: 1.0                                     # pcap play rate
+
+      rosbag_type:
+        correction_file_path: "Your correction file path"   # The path of correction file
+        firetimes_path: "Your firetime file path"           # The path of firetimes file
+
+      serial_type:
+        rs485_com: "Your serial port name for receiving point cloud"  # if using JT16, Port to receive the point cloud
+        rs232_com: "Your serial port name for sending cmd"            # if using JT16, Port to send cmd
+        point_cloud_baudrate: 3125000
+        correction_save_path: ""                                      # turn on when you need to store angle calibration files(from lidar)
+        correction_file_path: "Your correction file path"             # The path of correction file
+
+      # public module
+      use_timestamp_type: 0                 # 0 use point cloud timestamp; 1 use receive timestamp
+      frame_start_azimuth: 0                # Frame azimuth for Pandar128, range from 1 to 359, set it less than 0 if you do not want to use it
+      # parser thread num
+      thread_num: 4
+      # transform param
+      transform_flag: false
+      x: 0
+      y: 0
+      z: 0
+      roll: 0
+      pitch: 0
+      yaw: 0
+      # fov config, [fov_start, fov_end] range [1, 359], [-1, -1]means use default
+      fov_start: -1
+      fov_end:  -1
+      channel_fov_filter_path: "Your channel fov filter file path"  # The path of channel_fov_filter file, like channel 0 filter [10, 20] and [30,40]
+      multi_fov_filter_ranges: "" # compare to channel_fov_filter_path, multi_fov_filter_ranges for all channels. example config "[20,30];[40,200]"
+      # other config
+      enable_packet_loss_tool: true         # enable the udp packet loss detection tool
+      distance_correction_flag: false       # set to true when optical centre correction needs to be turned on
+      xt_spot_correction: false             # Set to TRUE when XT S point cloud layering correction is required
+      device_udp_src_port: 0                # Filter point clouds for specified source ports in case of multiple lidar, setting >=1024
+      device_fault_port: 0                  # Filter fault message for specified source ports in case of multiple lidar, setting >=1024
+      frame_frequency: 0                    # The frequency that point cloud sends.
+      default_frame_frequency: 10.0         # The default frequency that point cloud sends.
+      echo_mode_filter: 0                   # return mode filter
+
+    ros:
+      ros_frame_id: lidar3d_0_laser                       # Frame id of packet message and point cloud message
+      ros_recv_packet_topic: /lidar_packets               # Topic used to receive lidar packets from rosbag
+      ros_send_packet_topic: /lidar_packets               # Topic used to send lidar raw packets through ROS
+      ros_send_point_cloud_topic: /lidar_points           # Topic used to send point cloud through ROS
+      ros_send_imu_topic: /lidar_imu                      # Topic used to send lidar imu message
+      ros_send_packet_loss_topic: /lidar_packets_loss     # Topic used to monitor packets loss condition through ROS
+      # ros_recv_correction_topic: /lidar_corrections     # Topic used to receive corrections file from rosbag
+      # ros_send_correction_topic: /lidar_corrections     # Topic used to send correction through ROS
+      # ros_send_ptp_topic: /lidar_ptp                    # Topic used to send PTP lock status, offset through ROS
+      # ros_send_every_packet_topic: /lidar_every_packet  # Topic used to send every packet through ROS
+      send_packet_ros: false                              # true: Send packets through ROS
+      send_point_cloud_ros: true                          # true: Send point cloud through ROS
+      send_imu_ros: true                                  # true: Send imu through ROS

--- a/clearpath_sensors/config/hesai_lidar.yaml
+++ b/clearpath_sensors/config/hesai_lidar.yaml
@@ -1,0 +1,9 @@
+# Default parameters for the Hesai lidar bring-up.
+#
+# The upstream hesai_ros_driver_node only consumes a single ROS parameter,
+# `config_path`, which points at a YAML file the driver parses itself
+# (network, model, topic names, transforms, etc). Override this file to
+# point at a custom driver YAML if the shipped one is not appropriate.
+hesai_driver:
+  ros__parameters:
+    config_path: /opt/ros/jazzy/share/clearpath_sensors/config/hesai_config.yaml

--- a/clearpath_sensors/launch/hesai_lidar.launch.py
+++ b/clearpath_sensors/launch/hesai_lidar.launch.py
@@ -1,0 +1,77 @@
+# Software License Agreement (BSD)
+#
+# @copyright (c) 2026, Clearpath Robotics, Inc., All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# * Redistributions of source code must retain the above copyright notice,
+#   this list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# * Neither the name of Clearpath Robotics nor the names of its contributors
+#   may be used to endorse or promote products derived from this software
+#   without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
+from launch_ros.actions import Node
+from launch_ros.substitutions import FindPackageShare
+
+
+def generate_launch_description():
+
+    namespace = LaunchConfiguration('namespace')
+    parameters = LaunchConfiguration('parameters')
+    robot_namespace = LaunchConfiguration('robot_namespace')
+
+    arg_namespace = DeclareLaunchArgument('namespace', default_value='')
+
+    arg_robot_namespace = DeclareLaunchArgument('robot_namespace', default_value='')
+
+    arg_parameters = DeclareLaunchArgument(
+        'parameters',
+        default_value=PathJoinSubstitution(
+            [FindPackageShare('clearpath_sensors'), 'config', 'hesai_lidar.yaml']
+        ),
+    )
+
+    # The Hesai driver reads its device/network/topic settings from a YAML pointed
+    # to by the `config_path` ROS parameter, not from standard ROS parameters.
+    # See clearpath_sensors/config/hesai_lidar.yaml.
+    hesai_driver_node = Node(
+        package='hesai_ros_driver',
+        executable='hesai_ros_driver_node',
+        name='hesai_driver',
+        namespace=namespace,
+        output='screen',
+        parameters=[parameters],
+        remappings=[
+            ('/diagnostics', PathJoinSubstitution(['/', robot_namespace, 'diagnostics'])),
+            ('/tf', PathJoinSubstitution(['/', robot_namespace, 'tf'])),
+            ('/tf_static', PathJoinSubstitution(['/', robot_namespace, 'tf_static'])),
+            ('/lidar_points', 'points'),
+            ('/lidar_packets', 'packets'),
+            ('/lidar_packets_loss', 'packets_loss'),
+            ('/lidar_imu', 'imu'),
+        ],
+    )
+
+    ld = LaunchDescription()
+    ld.add_action(arg_namespace)
+    ld.add_action(arg_robot_namespace)
+    ld.add_action(arg_parameters)
+    ld.add_action(hesai_driver_node)
+    return ld


### PR DESCRIPTION
# Pull Request

## Description

RPSW-2837

Added hesai_lidar.yaml that points to the hesai_config.yaml taken from the HesaiLidar_ROS_2.0 repo.

Added hesai_lidar.launch.py.

Building and installing the HesaiLidar_ROS_2.0 repo from source code is a dependency for these changes.

## Related pull requests

- [clearpath_robot](https://github.com/clearpathrobotics/clearpath_robot/pull/355)
- [clearpath_common](https://github.com/clearpathrobotics/clearpath_common/pull/380)
- [clearpath_config](https://github.com/clearpathrobotics/clearpath_config/pull/250)
- [cpr-documentation](https://github.com/clearpathrobotics/cpr-documentation/pull/684)
- [clearpath_generator_tests](https://github.com/clearpathrobotics/clearpath_generator_tests/pull/20)

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Other (please describe):

## How has this been tested?

After building and running the [Hesai Lidar ROS repo](https://github.com/HesaiTechnology/HesaiLidar_ROS_2.0) Add the "hesai_lidar" to the robot.yaml and building the clearpath_common and clearpath_config with this branch and run 
` ros2 launch clearpath_viz view_robot.launch.py namespace:=a300_0000 setup_path:=/home/mibrahim/ros2_ws/`
Attached is the robot.yaml and a screen shot.
<img width="1596" height="988" alt="Screenshot from 2026-08-27 16-34-47" src="https://github.com/user-attachments/assets/dcca80b0-9e1e-44f7-9012-4895f4ba15ba" />

[robot.yaml](https://github.com/user-attachments/files/31658067/robot.yaml.txt)


## Checklist

- [x] I have read and followed the [contributing guidelines](CONTRIBUTING.md)
- [x] The workspace builds (`colcon build`)
- [x] Tests pass (`colcon test`)
- [x] The [generator tests](https://github.com/clearpathrobotics/clearpath_generator_tests) pass
- [x] I have added or updated tests where appropriate
- [x] I have updated documentation where appropriate