### PR TITLE
Fix: Re-calibrate A200 wheel travel offset on first activation to fix…

### DIFF
--- a/clearpath_hardware_interfaces/src/a200/hardware.cpp
+++ b/clearpath_hardware_interfaces/src/a200/hardware.cpp
@@ -416,6 +416,7 @@ hardware_interface::CallbackReturn A200Hardware::on_activate(const rclcpp_lifecy
   RCLCPP_INFO(rclcpp::get_logger(HW_NAME), "Starting ...please wait...");
 
   // set some default values
+  bool first_activation = false;
   for (auto i = 0u; i < hw_states_position_.size(); i++)
   {
     if (std::isnan(hw_states_position_[i]))
@@ -424,7 +425,15 @@ hardware_interface::CallbackReturn A200Hardware::on_activate(const rclcpp_lifecy
       hw_states_position_offset_[i] = 0;
       hw_states_velocity_[i] = 0;
       hw_commands_[i] = 0;
+      first_activation = true;
     }
+  }
+
+  // hw_states_position_offset_ was just zeroed above, so re-calibrate it against the
+  // current encoder travel.
+  if (first_activation)
+  {
+    resetTravelOffset();
   }
 
   RCLCPP_INFO(rclcpp::get_logger(HW_NAME), "System Successfully started!");


### PR DESCRIPTION
# Pull Request

## Description

Re-calibrate A200 wheel travel offset on first activation to fix false startup odometry.

## Related issue

Fixes #357 
## Related pull requests

N/A

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Other (please describe):

## How has this been tested?

User verified it resolved the issue.
## Checklist

- [x] I have read and followed the [contributing guidelines](CONTRIBUTING.md)
- [x] The workspace builds (`colcon build`)
- [x] Tests pass (`colcon test`)
- [x] The [generator tests](https://github.com/clearpathrobotics/clearpath_generator_tests) pass
- [x] I have added or updated tests where appropriate
- [x] I have updated documentation where appropriate
